### PR TITLE
fix: import all models in init_db before schema creation

### DIFF
--- a/api-rally/app/db/init_db.py
+++ b/api-rally/app/db/init_db.py
@@ -5,10 +5,20 @@ from app.core.config import settings
 from app.models.base import Base
 from .session import engine
 
+# IMPORTANT: Import all models here so they're registered with Base.metadata
+# before create_all() is called. Otherwise tables will be missing columns!
+from app.models import (  # noqa: F401
+    User,
+    Team,
+    CheckPoint,
+    RallyStaffAssignment,
+    Activity,
+    ActivityResult,
+    RallyEvent,
+    RallySettings,
+)
 
-# make sure all SQL Alchemy models are imported (app.db.base) before initializing DB
-# otherwise, SQL Alchemy might fail to initialize relationships properly
-# for more details: https://github.com/tiangolo/full-stack-fastapi-postgresql/issues/28
+# For more details: https://github.com/tiangolo/full-stack-fastapi-postgresql/issues/28
 
 
 def init_db() -> None:


### PR DESCRIPTION
PROBLEM:
- Rally API failed with 'column user.email does not exist' on first deployment
- SQLAlchemy's Base.metadata.create_all() was called without importing models
- Result: Tables created without all columns defined in models

ROOT CAUSE:
- init_db.py only imported Base class, not actual model classes (User, Team, etc.)
- When Base.metadata.create_all() ran, SQLAlchemy didn't know about the models
- Comment mentioned importing models but code didn't actually do it

SOLUTION:
- Import all model classes (User, Team, CheckPoint, Activity, etc.) in init_db.py
- Models are now registered with Base.metadata before create_all() is called
- All columns (including email) are now created correctly

IMPACT:
- Fixes 500 errors on user-related endpoints in production
- Schema now creates correctly on first deployment
- No migration needed for new deployments

Related: #<issue-number> (if applicable)