### PR TITLE
fix(ci): correct build context for web production Dockerfile

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Build web production image
         uses: docker/build-push-action@v5
         with:
-          context: ./web-rally
+          context: .
           file: ./web-rally/Dockerfile.prod
           push: false
           tags: rally-web:prod


### PR DESCRIPTION
The Dockerfile.prod uses a multi-stage build that needs access to both api-rally/ and web-rally/ directories (to generate OpenAPI schema from the API and then build the web frontend).

Changed build context from './web-rally' to '.' (repo root) to match the compose.override.prod.yml configuration which uses 'extensions/rally' as the context.

Fixes: ENOENT error when trying to copy api-rally files during build