### PR TITLE
rally: show tab to staff; fix staff assignment detection\n\n- Add ral…

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
         "endpoint": "/api/rally/v1/rally/settings/public",
         "field": "public_access_enabled",
         "value": true,
-        "fallbackScopes": ["manager-rally", "admin"]
+        "fallbackScopes": ["manager-rally", "admin", "rally-staff"]
       }
     }
   ],


### PR DESCRIPTION
This pull request introduces improvements to staff access handling and configuration for checkpoint access. The main focus is on allowing staff members to access checkpoints even if they do not have a corresponding local `User` record, and updating access scopes for public settings.

Staff access logic improvements:

* Updated the `get_staff_with_checkpoint_access` function in `abac_deps.py` to construct a `DetailedUser` object directly from authentication claims when a local `User` record does not exist, ensuring staff-only access works without requiring a local database entry.

Configuration and permissions:

* Added `"rally-staff"` to the `fallbackScopes` in the `manifest.json` for public access settings, expanding access permissions to include staff roles.…ly-staff to manifest fallbackScopes\n- Build DetailedUser from JWT when local row missing; attach staff checkpoint\n- Ensure staff evaluation redirects to assigned checkpoint