### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: Rally Extension Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/NEI-AAUAV/Platform-rally-extension/security/code-scanning/2](https://github.com/NEI-AAUAV/Platform-rally-extension/security/code-scanning/2)

The best way to fix this problem is to explicitly declare a `permissions` block that restricts the GITHUB_TOKEN permissions as much as possible, ideally to read-only (`contents: read`)—either at the top level of the workflow (before `jobs:`), so that it applies to all jobs, or at the job level for each job. Since none of these jobs appear to need any write access, and only need to read code and use artifacts, setting `contents: read` at the workflow level would be best. You should add the following block after the workflow `name:` and before `on:`:

```yaml
permissions:
  contents: read
```

This instructs GitHub Actions to only grant read access to repository content for the duration of the workflow, significantly reducing security risk if any step were compromised.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a top-level `permissions: contents: read` to `.github/workflows/tests.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a9156a95a387ab4016476dd9722786913b8c4d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->