### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/api-rally/app/services/scoring_service.py
+++ b/api-rally/app/services/scoring_service.py
@@ -3,6 +3,7 @@ Scoring system service for Rally activities
 """
 from typing import Dict, Any, List, Optional, Tuple
 from sqlalchemy.orm import Session, joinedload
+import logging
 from datetime import datetime, timezone
 
 from app.models.activity import ActivityResult, Activity
@@ -346,4 +347,5 @@ class ScoringService:
             
         except Exception as e:
             self.db.rollback()
-            return False, f"Error creating team vs team results: {str(e)}"
+            logging.exception("Exception occurred in create_team_vs_result")
+            return False, "An internal error occurred while creating the team vs team results."


### PR DESCRIPTION
Potential fix for [https://github.com/NEI-AAUAV/Platform-rally-extension/security/code-scanning/4](https://github.com/NEI-AAUAV/Platform-rally-extension/security/code-scanning/4)

To fix the issue, we should sanitize the error message returned from `ScoringService.create_team_vs_result` so that internal exception details are not sent back to end users via API responses. Instead, the method should return a generic error message to API clients, while logging the true exception (including stack trace) on the server for debugging. Specifically, in `create_team_vs_result`, replace the `str(e)` in the returned message (line 349) with a generic and non-sensitive string such as `"An internal error occurred while creating the team vs team results."`, and optionally add server-side logging of the real exception for diagnostics. This change is entirely within the `api-rally/app/services/scoring_service.py` file; no changes are required in `api-rally/app/api/api_v1/activities.py`. For logging, we can use Python's built-in `logging` module, which is standard and well-known.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sanitizes error messages in `create_team_vs_result` to avoid leaking exceptions and logs the full exception server-side.
> 
> - **Security/Error handling**:
>   - In `api-rally/app/services/scoring_service.py` (`ScoringService.create_team_vs_result`):
>     - Replace user-facing error detail `str(e)` with a generic message to prevent information exposure.
>     - Add `logging.exception(...)` to record the full stack trace server-side.
>     - Import `logging` to support server-side logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d3963cb2a87f261457a3f759842b1f0b9b32fc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->