### PR TITLE
fix:  team session management and navigation

### DIFF
--- a/web-rally/Dockerfile
+++ b/web-rally/Dockerfile
@@ -2,7 +2,7 @@ FROM node:24-alpine AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 
-RUN npm install -g pnpm
+RUN npm install -g pnpm@9.12.0
 
 WORKDIR /web_rally
 

--- a/web-rally/package.json
+++ b/web-rally/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "packageManager": "pnpm@9.12.0",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/web-rally/src/components/shared/navigation/MobileBottomNav.tsx
+++ b/web-rally/src/components/shared/navigation/MobileBottomNav.tsx
@@ -25,6 +25,7 @@ import useTeamAuth from "@/hooks/useTeamAuth";
 import { TeamQrCard } from "@/components/checkin/TeamQrCard";
 import { useTabScrub } from "./useTabScrub";
 import { useBackDismiss } from "@/hooks/useBackDismiss";
+import { useViewModeStore } from "@/stores/useViewModeStore";
 
 interface NavItem {
   readonly name: string;
@@ -62,14 +63,18 @@ export function MobileBottomNav() {
   const isGuide = scopes !== undefined && scopes.includes("rally-guide");
   const isPrivileged = isAdminOrManager || isStaff;
   const { showGuideFeature } = useGuideAccess();
+  const { viewMode } = useViewModeStore();
 
   const showScore = settings?.show_score_mode !== "hidden";
   const showPostos = isPrivileged || settings?.show_checkpoint_map === true;
   const checkpointsLabel = capitalize(useEventTerms().checkpoints);
 
-  // Any authenticated team (incl. dual-role staff/admin) gets the team
-  // destinations + QR FAB; privileged-only users keep the public/staff nav.
-  const showTeamNav = isTeamAuthenticated;
+  // Team-only users always get the team destinations + QR FAB. Dual-role
+  // users (also staff/admin/guide) follow the same team/staff view toggle as
+  // the desktop navbar (useViewModeStore) — otherwise a dual-role team could
+  // see "Equipa"/"Definições" here while the desktop navbar (still on its
+  // default "staff" view) hides them, or vice versa.
+  const showTeamNav = isTeamAuthenticated && (!isPrivileged || viewMode === "team");
   const accessCode = team?.access_code;
 
   const items: NavItem[] = showTeamNav

--- a/web-rally/src/components/shared/navigation/MobileBottomNav.tsx
+++ b/web-rally/src/components/shared/navigation/MobileBottomNav.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import type { ComponentType } from "react";
 import { cn } from "@/lib/utils";
+import { isNavItemActive } from "./activeRoute";
 import { useUserStore } from "@/stores/useUserStore";
 import useRallySettings from "@/hooks/useRallySettings";
 import useGuideAccess from "@/hooks/useGuideAccess";
@@ -30,6 +31,8 @@ interface NavItem {
   readonly href: string;
   readonly Icon: ComponentType<{ className?: string }>;
   readonly show: boolean;
+  /** Extra paths that should also light this tab (e.g. a redirect source). */
+  readonly aliases?: readonly string[];
 }
 
 /**
@@ -71,7 +74,16 @@ export function MobileBottomNav() {
 
   const items: NavItem[] = showTeamNav
     ? [
-        { name: "Progresso", href: "/team-progress", Icon: Home, show: true },
+        {
+          name: "Progresso",
+          href: "/team-progress",
+          Icon: Home,
+          show: true,
+          // "/" (PWA start_url, navbar logo, achievements/team-settings
+          // Navigate targets) redirects a signed-in team straight here; light
+          // this tab immediately instead of leaving none lit mid-redirect.
+          aliases: ["/"],
+        },
         { name: "Pontos", href: "/scoreboard", Icon: Trophy, show: showScore },
         { name: checkpointsLabel, href: "/checkpoints", Icon: MapPin, show: showPostos },
         {
@@ -115,7 +127,9 @@ export function MobileBottomNav() {
       ].filter((i) => i.show);
 
   const showQrFab = showTeamNav && !!accessCode;
-  const activeIndex = items.findIndex((item) => location.pathname === item.href);
+  const activeIndex = items.findIndex((item) =>
+    isNavItemActive(location.pathname, item.href, item.aliases),
+  );
 
   const goToTab = useCallback(
     (index: number) => {
@@ -132,7 +146,7 @@ export function MobileBottomNav() {
   });
 
   const renderTab = (item: NavItem, index: number) => {
-    const isActive = location.pathname === item.href;
+    const isActive = isNavItemActive(location.pathname, item.href, item.aliases);
     // While scrubbing, the tab under the finger lights up instead of the
     // route's own tab — the screen has not changed yet.
     const isLit = hoverIndex >= 0 ? hoverIndex === index : isActive;

--- a/web-rally/src/components/shared/navigation/activeRoute.ts
+++ b/web-rally/src/components/shared/navigation/activeRoute.ts
@@ -1,0 +1,22 @@
+/**
+ * Whether a nav item should read as "active" for the current pathname.
+ *
+ * `/` only matches exactly — every other route starts with `/`, so a naive
+ * prefix check would light up "Início" everywhere. Every other href matches
+ * itself and its nested routes by segment (`/staff-evaluation` stays lit on
+ * `/staff-evaluation/checkpoint/1`), and `aliases` covers redirect targets
+ * that never carry the item's own href (e.g. the team home redirecting `/`
+ * to `/team-progress`).
+ */
+export function isNavItemActive(
+  pathname: string,
+  href: string,
+  aliases: readonly string[] = [],
+): boolean {
+  return [href, ...aliases].some((candidate) => matchesRoute(pathname, candidate));
+}
+
+function matchesRoute(pathname: string, candidate: string): boolean {
+  if (candidate === "/") return pathname === "/";
+  return pathname === candidate || pathname.startsWith(`${candidate}/`);
+}

--- a/web-rally/src/components/shared/navigation/nav-tabs.tsx
+++ b/web-rally/src/components/shared/navigation/nav-tabs.tsx
@@ -1,5 +1,6 @@
 import { Link, useLocation } from "@tanstack/react-router";
 import { cn } from "@/lib/utils";
+import { isNavItemActive } from "./activeRoute";
 import { RallyButton } from "@/components/themes/rally";
 import type { ComponentProps } from "react";
 import { useUserStore } from "@/stores/useUserStore";
@@ -56,7 +57,7 @@ function NavGroup({
 
   useClickOutside(ref, open, () => setOpen(false));
 
-  const hasActive = items.some((i) => i.href === location.pathname);
+  const hasActive = items.some((i) => isNavItemActive(location.pathname, i.href));
 
   return (
     <div
@@ -81,7 +82,7 @@ function NavGroup({
         <div className="absolute left-1/2 top-full z-50 -translate-x-1/2 pt-2">
           <ul className="rally-elevate min-w-[10rem] space-y-0.5 overflow-hidden rounded-xl border border-border bg-popover p-1.5">
             {items.map((item) => {
-              const isActive = location.pathname === item.href;
+              const isActive = isNavItemActive(location.pathname, item.href);
               return (
                 <li key={item.name}>
                   <Link
@@ -198,6 +199,8 @@ export default function NavTabs({ className, ...props }: NavTabsProps) {
       href: "/achievements",
       show: showTeamView && settings?.badges_enabled !== false,
     },
+    { name: "Equipa", href: "/team-info", show: showTeamView },
+    { name: "Definições", href: "/team-settings", show: showTeamView },
     { name: "Trocar Equipa", href: "/team-login", show: showTeamView },
 
     { name: "Pontuação", href: "/scoreboard", show: !showTeamView && showScoreMenu },
@@ -227,7 +230,7 @@ export default function NavTabs({ className, ...props }: NavTabsProps) {
   ].filter((item) => item.show);
 
   const renderLink = (item: NavLink, isSidebar = false) => {
-    const isActive = location.pathname === item.href;
+    const isActive = isNavItemActive(location.pathname, item.href);
     return (
       <li key={`${item.name}-${item.href}`}>
         <Link
@@ -378,7 +381,7 @@ export default function NavTabs({ className, ...props }: NavTabsProps) {
                 onClick={() => setIsMobileMenuOpen(false)}
                 className={cn(
                   "flex items-center gap-2",
-                  linkClass(location.pathname === "/preferences", true),
+                  linkClass(isNavItemActive(location.pathname, "/preferences"), true),
                 )}
               >
                 <SlidersHorizontal className="h-4 w-4" />

--- a/web-rally/src/components/shared/navigation/nav-tabs.tsx
+++ b/web-rally/src/components/shared/navigation/nav-tabs.tsx
@@ -23,11 +23,9 @@ import useTeamAuth from "@/hooks/useTeamAuth";
 import useStaffLogin from "@/hooks/useLoginLink";
 import useClickOutside from "@/hooks/useClickOutside";
 import { useBackDismiss } from "@/hooks/useBackDismiss";
+import { useViewModeStore, type ViewMode } from "@/stores/useViewModeStore";
 
 type NavTabsProps = ComponentProps<"ul">;
-
-const VIEW_MODE_KEY = "rally_view_mode";
-type ViewMode = "team" | "staff";
 
 interface NavLink {
   readonly name: string;
@@ -166,18 +164,12 @@ export default function NavTabs({ className, ...props }: NavTabsProps) {
   const { isAdminOrManager, isStaff, isGuide, isPrivileged } = deriveRoleFlags(scopes);
   const { showGuideFeature } = useGuideAccess();
   const isDualRole = isPrivileged && isTeamAuthenticated;
+  const showPostos = isPrivileged || settings?.show_checkpoint_map === true;
 
-  const [viewMode, setViewMode] = useState<ViewMode>(() => {
-    if (typeof window !== "undefined") {
-      return (localStorage.getItem(VIEW_MODE_KEY) as ViewMode) ?? "staff";
-    }
-    return "staff";
-  });
+  const { viewMode, toggleViewMode: toggleViewModeStore } = useViewModeStore();
 
   const toggleViewMode = () => {
-    const next: ViewMode = viewMode === "staff" ? "team" : "staff";
-    setViewMode(next);
-    localStorage.setItem(VIEW_MODE_KEY, next);
+    toggleViewModeStore();
     setIsMobileMenuOpen(false);
   };
 
@@ -194,6 +186,7 @@ export default function NavTabs({ className, ...props }: NavTabsProps) {
   const primary: NavLink[] = [
     { name: "Progresso", href: "/team-progress", show: showTeamView },
     { name: "Pontuação", href: "/scoreboard", show: showTeamView && showScoreMenu },
+    { name: checkpointsLabel, href: "/checkpoints", show: showTeamView && showPostos },
     {
       name: "Conquistas",
       href: "/achievements",

--- a/web-rally/src/components/shared/navigation/user-menu.tsx
+++ b/web-rally/src/components/shared/navigation/user-menu.tsx
@@ -1,6 +1,16 @@
 import { useUserStore } from "@/stores/useUserStore";
+import useTeamAuth from "@/hooks/useTeamAuth";
 import { Link } from "@tanstack/react-router";
-import { Settings, SlidersHorizontal, LogOut, UserPlus, LogIn, Users, User } from "lucide-react";
+import {
+  Settings,
+  SlidersHorizontal,
+  LogOut,
+  UserPlus,
+  LogIn,
+  Users,
+  User,
+  RefreshCw,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import useStaffLogin from "@/hooks/useLoginLink";
 
@@ -8,6 +18,7 @@ export function UserMenu() {
   const { isAuthenticated, name, email, image, scopes, logout, sessionLoading } = useUserStore(
     (state) => state,
   );
+  const { isAuthenticated: isTeamAuthenticated, teamData, logout: teamLogout } = useTeamAuth();
   const onStaffLogin = useStaffLogin();
 
   const isAdmin =
@@ -18,6 +29,53 @@ export function UserMenu() {
 
   if (sessionLoading) {
     return <div className="h-9 w-20 animate-pulse rounded-md border border-border bg-muted" />;
+  }
+
+  // Team-only identity (no OIDC session): show the team's name and its own
+  // menu instead of the anonymous login buttons — a code-only session is a
+  // real identity, not a visitor.
+  if (!isAuthenticated && isTeamAuthenticated && teamData) {
+    return (
+      <div className="group relative hidden cursor-pointer items-center gap-2 rounded-md border border-border bg-card px-2 py-1 transition-colors hover:bg-accent sm:flex">
+        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary text-xs font-bold text-primary-foreground">
+          <Users className="h-4 w-4" />
+        </div>
+        <span className="max-w-[14ch] truncate text-sm font-semibold">{teamData.team_name}</span>
+
+        <div className="absolute right-0 top-full z-50 hidden w-52 pt-2 group-hover:block">
+          <div className="rally-elevate flex flex-col overflow-hidden rounded-lg border border-border bg-popover">
+            <div className="border-b border-border px-4 py-3">
+              <p className="truncate text-sm font-semibold text-popover-foreground">
+                {teamData.team_name}
+              </p>
+              <p className="text-xs text-muted-foreground">Sessão de equipa</p>
+            </div>
+            <Link
+              to="/team-settings"
+              className="flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm font-medium text-popover-foreground transition-colors hover:bg-accent"
+            >
+              <Settings className="h-4 w-4" />
+              Definições da equipa
+            </Link>
+            <Link
+              to="/team-login"
+              className="flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm font-medium text-popover-foreground transition-colors hover:bg-accent"
+            >
+              <RefreshCw className="h-4 w-4" />
+              Trocar equipa
+            </Link>
+            <button
+              type="button"
+              onClick={teamLogout}
+              className="flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm font-medium text-destructive transition-colors hover:bg-destructive hover:text-destructive-foreground"
+            >
+              <LogOut className="h-4 w-4" />
+              Terminar sessão de equipa
+            </button>
+          </div>
+        </div>
+      </div>
+    );
   }
 
   if (!isAuthenticated) {

--- a/web-rally/src/hooks/useTeamAuth.ts
+++ b/web-rally/src/hooks/useTeamAuth.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   getTeamById,
@@ -12,12 +12,11 @@ import { setSentryUser, clearSentryUser } from "@/lib/sentry";
 import {
   getTeamToken,
   setTeamToken,
-  getTeamData,
   setTeamData,
-  hasTeamData,
   clearTeamAuth,
   type TeamTokenData,
 } from "@/lib/auth/tokenStore";
+import { useTeamStore } from "@/stores/useTeamStore";
 
 interface TeamLoginResponse {
   access_token: string;
@@ -31,26 +30,19 @@ interface TeamLoginResponse {
  * Provides login, logout, and authentication state management
  */
 export default function useTeamAuth() {
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
-  const [currentTeamData, setCurrentTeamData] = useState<TeamTokenData | null>(null);
-  const [isLoadingAuth, setIsLoadingAuth] = useState(true);
+  const isAuthenticated = useTeamStore((state) => state.isAuthenticated);
+  const currentTeamData = useTeamStore((state) => state.teamData);
+  const setSession = useTeamStore((state) => state.setSession);
+  const clearStore = useTeamStore((state) => state.clear);
   const queryClient = useQueryClient();
 
-  // Check for existing token on mount
+  // The store is seeded synchronously from localStorage at module init, so
+  // there is no loading window for team auth itself (unlike the OIDC side,
+  // which waits on a network round-trip). Sentry identity mirrors whatever
+  // the store already holds.
   useEffect(() => {
-    const token = getTeamToken();
-    const data = getTeamData();
-
-    if (token && data) {
-      setCurrentTeamData(data);
-      setIsAuthenticated(true);
-      setSentryUser(data.team_id);
-    } else if (token && hasTeamData()) {
-      // Token present and a data entry exists but is corrupt — clear stale storage.
-      clearTeamAuth();
-    }
-    setIsLoadingAuth(false);
-  }, []);
+    if (currentTeamData) setSentryUser(currentTeamData.team_id);
+  }, [currentTeamData]);
 
   // Fetch team members data when authenticated
   const { data: team, isLoading: isLoadingTeam } = useQuery<PrivilegedDetailedTeam>({
@@ -88,9 +80,7 @@ export default function useTeamAuth() {
       };
       setTeamToken(data.access_token);
       setTeamData(teamTokenData);
-
-      setCurrentTeamData(teamTokenData);
-      setIsAuthenticated(true);
+      setSession(teamTokenData);
       setSentryUser(data.team_id);
     },
   });
@@ -128,8 +118,7 @@ export default function useTeamAuth() {
 
   const logout = () => {
     clearTeamAuth();
-    setIsAuthenticated(false);
-    setCurrentTeamData(null);
+    clearStore();
     clearSentryUser();
     void queryClient.invalidateQueries({ queryKey: ["team"] });
   };
@@ -142,7 +131,7 @@ export default function useTeamAuth() {
     isAuthenticated,
     teamData: currentTeamData,
     team,
-    isLoading: isLoadingAuth || isLoadingTeam,
+    isLoading: isLoadingTeam,
     login,
     logout,
     getToken,

--- a/web-rally/src/pages/layout.tsx
+++ b/web-rally/src/pages/layout.tsx
@@ -41,16 +41,25 @@ function MainLayoutContent() {
   // rules, scoreboard) must still gate behind LandingGate, or
   // public_access_enabled=false stops blocking anonymous visitors there.
   const publicPaths = ["/team-login", "/team-progress", "/versus"];
+  // Staff-only flows must always require auth, independent of public_access_enabled
+  // and regardless of whether the settings fetch itself failed (e.g. an expired
+  // staff session also breaks the settings call) — otherwise a fail-open settings
+  // fetch silently lets an expired/unauthenticated staff session through.
+  const staffOnlyPaths = ["/staff-evaluation"];
   const currentPath = useLocation({ select: (state) => state.pathname });
   const isPublicPath = publicPaths.some(
     (path) => currentPath === path || currentPath.startsWith(`${path}/`),
   );
+  const isStaffOnlyPath = staffOnlyPaths.some(
+    (path) => currentPath === path || currentPath.startsWith(`${path}/`),
+  );
 
-  // Redirect to main platform login if not authenticated and public access is disabled
-  // AND we are not on a specifically allowed public/team path
+  // Redirect to main platform login if not authenticated and either public access
+  // is disabled or this is a staff-only path, AND we are not on a specifically
+  // allowed public/team path.
   if (
     !isAuthenticated &&
-    !isPublicAccessEnabled &&
+    (isStaffOnlyPath || !isPublicAccessEnabled) &&
     !isPublicPath &&
     !sessionLoading &&
     !settingsLoading

--- a/web-rally/src/pages/layout.tsx
+++ b/web-rally/src/pages/layout.tsx
@@ -36,17 +36,11 @@ function MainLayoutContent() {
   // settings-fetch error locks every visitor out.
   const isPublicAccessEnabled = settings === undefined || settings.public_access_enabled === true;
 
-  // Paths that are accessible for teams or public even if main public access is disabled
-  const publicPaths = [
-    "/",
-    "/team-login",
-    "/team-progress",
-    "/versus",
-    "/scoreboard",
-    "/checkpoints",
-    "/rules",
-    "/preferences",
-  ];
+  // Paths that are accessible for teams or public even if main public access is disabled.
+  // Keep this to team-only flows — general public pages (home, checkpoints,
+  // rules, scoreboard) must still gate behind LandingGate, or
+  // public_access_enabled=false stops blocking anonymous visitors there.
+  const publicPaths = ["/team-login", "/team-progress", "/versus"];
   const currentPath = useLocation({ select: (state) => state.pathname });
   const isPublicPath = publicPaths.some(
     (path) => currentPath === path || currentPath.startsWith(`${path}/`),

--- a/web-rally/src/pages/layout.tsx
+++ b/web-rally/src/pages/layout.tsx
@@ -9,7 +9,8 @@ import useRallySettings from "@/hooks/useRallySettings";
 import useDocumentBranding from "@/hooks/useDocumentBranding";
 import { resolveBranding } from "@/lib/branding";
 import { useUserStore } from "@/stores/useUserStore";
-import { Outlet } from "@tanstack/react-router";
+import { useTeamStore } from "@/stores/useTeamStore";
+import { Outlet, useLocation } from "@tanstack/react-router";
 import { ThemeProvider, useTheme } from "@/components/themes";
 
 function MainLayoutContent() {
@@ -19,6 +20,7 @@ function MainLayoutContent() {
   const { themeName, buttonStyle, backgroundStyle } = useTheme();
 
   const { sub, sessionLoading } = useUserStore((state) => state);
+  const isTeamAuthenticated = useTeamStore((state) => state.isAuthenticated);
   const onStaffLogin = useStaffLogin();
   const { settings, isLoading: settingsLoading } = useRallySettings();
 
@@ -27,15 +29,28 @@ function MainLayoutContent() {
   const branding = resolveBranding(settings);
   useDocumentBranding(branding);
 
-  // Check if user is authenticated OR if public access is enabled
-  const isAuthenticated = sub !== undefined;
-  const isPublicAccessEnabled = settings?.public_access_enabled === true;
+  // A signed-in team is a first-class identity here too, not just OIDC staff.
+  const isAuthenticated = sub !== undefined || isTeamAuthenticated;
+  // settings undefined means the request hasn't resolved (still loading, or
+  // failed) — never read that as "public access is off", or a transient
+  // settings-fetch error locks every visitor out.
+  const isPublicAccessEnabled = settings === undefined || settings.public_access_enabled === true;
 
   // Paths that are accessible for teams or public even if main public access is disabled
-  const publicPaths = ["/team-login", "/team-progress", "/versus"];
-  // Extract the path after /rally/ since the router basename is already /rally
-  const currentPath = globalThis.location.pathname.replace(/^\/rally/, "");
-  const isPublicPath = publicPaths.some((path) => currentPath.startsWith(path));
+  const publicPaths = [
+    "/",
+    "/team-login",
+    "/team-progress",
+    "/versus",
+    "/scoreboard",
+    "/checkpoints",
+    "/rules",
+    "/preferences",
+  ];
+  const currentPath = useLocation({ select: (state) => state.pathname });
+  const isPublicPath = publicPaths.some(
+    (path) => currentPath === path || currentPath.startsWith(`${path}/`),
+  );
 
   // Redirect to main platform login if not authenticated and public access is disabled
   // AND we are not on a specifically allowed public/team path

--- a/web-rally/src/pages/not-found/index.tsx
+++ b/web-rally/src/pages/not-found/index.tsx
@@ -1,0 +1,22 @@
+import { Compass } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/shared";
+
+/** Router-level 404, wired as `notFoundComponent` in `router/index.tsx`. */
+export default function NotFound() {
+  return (
+    <div className="mx-auto flex min-h-[60vh] max-w-md items-center justify-center px-4">
+      <EmptyState
+        icon={<Compass className="h-10 w-10 text-muted-foreground" />}
+        title="Página não encontrada"
+        description="O link que seguiste não existe ou foi movido."
+        action={
+          <Button asChild size="sm">
+            <Link to="/">Voltar ao início</Link>
+          </Button>
+        }
+      />
+    </div>
+  );
+}

--- a/web-rally/src/pages/rules/index.tsx
+++ b/web-rally/src/pages/rules/index.tsx
@@ -108,7 +108,7 @@ export default function Rules() {
       id: "badges",
       title: "Distintivos",
       Icon: Award,
-      show: true,
+      show: settings?.badges_enabled !== false,
       body: (
         <p className="text-sm text-muted-foreground">
           As equipas ganham distintivos por feitos especiais durante o rally (vitórias em versus,

--- a/web-rally/src/pages/team-info/index.tsx
+++ b/web-rally/src/pages/team-info/index.tsx
@@ -8,6 +8,7 @@ import { TeamMemberLinkService } from "@/services/TeamMemberLinkService";
 import { useAuth } from "react-oidc-context";
 import { LoadingState } from "@/components/shared";
 import { clearResumeValue, getResumeValue, setResumeValue } from "@/lib/authResumeStore";
+import { clearTeamAuth } from "@/lib/auth/tokenStore";
 
 const PENDING_LINK_MEMBER_KEY = "rally_pending_link_user_id";
 const PENDING_LINK_TEAM_KEY = "rally_pending_link_team_id";
@@ -30,6 +31,11 @@ export default function TeamInfo() {
       clearResumeValue(PENDING_LINK_MEMBER_KEY);
       clearResumeValue(PENDING_LINK_TEAM_KEY);
       clearResumeValue(PENDING_LINK_CODE_KEY);
+      // The team token may be stale/expired by now and races the OIDC session
+      // restore on reload (apiClient prefers whatever token exists first,
+      // sending a dead team token before react-oidc-context finishes
+      // restoring). Drop it so the reload authenticates via OIDC only.
+      clearTeamAuth();
       window.location.reload();
     } catch (error) {
       const message = error instanceof Error ? error.message : "Não foi possível associar a conta";

--- a/web-rally/src/router/index.tsx
+++ b/web-rally/src/router/index.tsx
@@ -1,9 +1,11 @@
 import { RouterProvider, createRouter } from "@tanstack/react-router";
 import { routeTree } from "./routes";
+import NotFound from "@/pages/not-found";
 
 const router = createRouter({
   routeTree,
   basepath: import.meta.env.BASE_URL.replace(/\/$/, "") || "/",
+  defaultNotFoundComponent: NotFound,
   // No defaultViewTransition here on purpose. The ::view-transition-new(root)
   // rule in global.css is the circular reveal written for the light/dark
   // toggle, and it applies to *any* root view transition — turning it on for

--- a/web-rally/src/router/routes.tsx
+++ b/web-rally/src/router/routes.tsx
@@ -1,5 +1,12 @@
-import { createRootRoute, createRoute, lazyRouteComponent, Navigate } from "@tanstack/react-router";
+import {
+  createRootRoute,
+  createRoute,
+  lazyRouteComponent,
+  Navigate,
+  redirect,
+} from "@tanstack/react-router";
 import MainLayout from "@/pages/layout";
+import { getTeamToken, getTeamData } from "@/lib/auth/tokenStore";
 
 const rootRoute = createRootRoute();
 
@@ -20,6 +27,16 @@ const layoutRoute = createRoute({
 const indexRoute = createRoute({
   getParentRoute: () => layoutRoute,
   path: "/",
+  // Both reads are synchronous localStorage lookups, so a signed-in team
+  // never paints the marketing landing (or a blank frame with no active nav
+  // tab) even for an instant — redirect before the route renders at all.
+  // The <Navigate> in pages/home/index.tsx stays as a fallback for whenever
+  // this beforeLoad is bypassed (e.g. tests mounting Home directly).
+  beforeLoad: () => {
+    if (getTeamToken() && getTeamData()) {
+      throw redirect({ to: "/team-progress" });
+    }
+  },
   component: lazyRouteComponent(() => import("@/pages/home")),
 });
 

--- a/web-rally/src/services/client.ts
+++ b/web-rally/src/services/client.ts
@@ -1,5 +1,6 @@
 import { getTeamToken, setTeamToken, clearTeamAuth } from "@/lib/auth/tokenStore";
 import { logger } from "@/lib/logger";
+import { useTeamStore } from "@/stores/useTeamStore";
 
 /**
  * HTTP auth glue for the generated OpenAPI client.
@@ -54,15 +55,25 @@ export async function refreshTeamToken(): Promise<string | undefined> {
     });
     if (!response.ok) {
       logger.warn("Team token refresh failed", { status: response.status });
-      clearTeamAuth();
+      // Only 401/403 mean the token itself is dead (expired/revoked) — clear
+      // it. Any other status (5xx, rate limiting) is a server-side hiccup;
+      // wiping a still-valid session over that would kick a team out of a
+      // live event on a transient blip.
+      if (response.status === 401 || response.status === 403) {
+        clearTeamAuth();
+        useTeamStore.getState().clear();
+      }
       return undefined;
     }
     const { access_token } = (await response.json()) as { access_token: string };
     setTeamToken(access_token);
+    useTeamStore.getState().setToken();
     return access_token;
   } catch (error) {
+    // Network failure (offline, timeout, DNS): keep the existing session —
+    // it may still be valid once connectivity returns. Only a confirmed
+    // 401/403 above should ever clear it.
     logger.warn("Team token refresh failed", { error: String(error) });
-    clearTeamAuth();
     return undefined;
   }
 }

--- a/web-rally/src/stores/useTeamStore.ts
+++ b/web-rally/src/stores/useTeamStore.ts
@@ -1,0 +1,75 @@
+import { create } from "zustand";
+import {
+  getTeamToken,
+  getTeamData,
+  hasTeamData,
+  clearTeamAuth,
+  type TeamTokenData,
+} from "@/lib/auth/tokenStore";
+
+/**
+ * Shared team-session identity, mirroring useUserStore's role for the OIDC
+ * side. Initialized synchronously from localStorage so the very first render
+ * (bottom nav, layout gate, etc.) already knows whether a team is signed in —
+ * no mount-effect frame where every consumer independently starts at
+ * `false`. Any writer (login mutation, boot-time refreshTeamToken, logout)
+ * updates this store directly so every consumer re-renders together.
+ */
+
+interface TeamState {
+  isAuthenticated: boolean;
+  teamData: TeamTokenData | null;
+  /** Populate the team session (login or a successful token refresh). */
+  setSession: (data: TeamTokenData) => void;
+  /** Token rotated by a refresh; team identity (id/name) is unchanged. */
+  setToken: () => void;
+  /** Clear the team session (logout, or a confirmed-dead token). */
+  clear: () => void;
+  /**
+   * Re-derive state from localStorage. The store is a module singleton
+   * seeded once at import, so anything that mutates localStorage directly
+   * (mainly tests) must call this to keep the store in sync — normal app
+   * code goes through setSession/clear instead.
+   */
+  hydrate: () => void;
+}
+
+function readInitialState(): Pick<TeamState, "isAuthenticated" | "teamData"> {
+  const token = getTeamToken();
+  const data = getTeamData();
+
+  if (token && data) {
+    return { isAuthenticated: true, teamData: data };
+  }
+  if (token && hasTeamData()) {
+    // Token present but the data entry is corrupt — treat as logged out and
+    // clear the stale storage so future reads don't repeat this check.
+    clearTeamAuth();
+  }
+  return { isAuthenticated: false, teamData: null };
+}
+
+export const useTeamStore = create<TeamState>((set) => ({
+  ...readInitialState(),
+
+  setSession: (data) => set({ isAuthenticated: true, teamData: data }),
+
+  // The refreshed token itself lives in localStorage (tokenStore); this store
+  // only tracks identity/auth-state, so a rotation is a no-op here beyond
+  // confirming the session is still alive.
+  setToken: () => set((state) => ({ ...state, isAuthenticated: true })),
+
+  clear: () => set({ isAuthenticated: false, teamData: null }),
+
+  hydrate: () => set(readInitialState()),
+}));
+
+// Keep other tabs/windows in sync: a login/logout in one tab should be
+// reflected here without a manual refresh.
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (event) => {
+    if (event.key !== "rally_team_token" && event.key !== "rally_team_data") return;
+    const { isAuthenticated, teamData } = readInitialState();
+    useTeamStore.setState({ isAuthenticated, teamData });
+  });
+}

--- a/web-rally/src/stores/useViewModeStore.ts
+++ b/web-rally/src/stores/useViewModeStore.ts
@@ -1,0 +1,41 @@
+import { create } from "zustand";
+
+const VIEW_MODE_KEY = "rally_view_mode";
+
+export type ViewMode = "team" | "staff";
+
+/**
+ * Persisted per-device preference for dual-role users (team + staff/admin/
+ * guide) choosing which nav surface to see. A zustand store rather than
+ * component-local state — NavTabs (desktop) and MobileBottomNav each used to
+ * carry their own copy, so toggling the view on one surface didn't update
+ * the other: a dual-role user could see "Equipa"/"Definições" on mobile but
+ * have them hidden behind the toggle on desktop (still defaulted to
+ * "staff"), or vice versa. One store keeps every consumer in agreement.
+ */
+interface ViewModeState {
+  viewMode: ViewMode;
+  toggleViewMode: () => void;
+}
+
+function readInitialViewMode(): ViewMode {
+  if (typeof window === "undefined") return "staff";
+  return (localStorage.getItem(VIEW_MODE_KEY) as ViewMode | null) ?? "staff";
+}
+
+export const useViewModeStore = create<ViewModeState>((set) => ({
+  viewMode: readInitialViewMode(),
+  toggleViewMode: () =>
+    set((state) => {
+      const next: ViewMode = state.viewMode === "staff" ? "team" : "staff";
+      localStorage.setItem(VIEW_MODE_KEY, next);
+      return { viewMode: next };
+    }),
+}));
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (event) => {
+    if (event.key !== VIEW_MODE_KEY) return;
+    useViewModeStore.setState({ viewMode: readInitialViewMode() });
+  });
+}

--- a/web-rally/tests/e2e/helpers/nav.ts
+++ b/web-rally/tests/e2e/helpers/nav.ts
@@ -13,14 +13,18 @@ export async function expectLoggedOutLoginCta(page: Page): Promise<void> {
   const menuButton = page.getByRole('button', { name: 'Abrir menu' });
 
   // Whichever renders for this viewport settles first; without this the check
-  // below can run before the header has hydrated and find neither.
-  await expect(inlineCta.or(menuButton).first()).toBeVisible({ timeout: 10000 });
+  // below can run before the header has hydrated and find neither. 20s (not
+  // the usual 10s) because a fully-parallel CI run of this spec saturates the
+  // single preview server, and hydration can lag well past 10s under that
+  // load without the app actually being broken (see staff-evaluation CI runs
+  // where this timed out at 10s with 2 retries but a solo run passed easily).
+  await expect(inlineCta.or(menuButton).first()).toBeVisible({ timeout: 20000 });
   if (await inlineCta.isVisible()) {
     return;
   }
 
   await menuButton.click();
   await expect(page.getByRole('button', { name: /iniciar sessão/i })).toBeVisible({
-    timeout: 5000,
+    timeout: 10000,
   });
 }

--- a/web-rally/tests/e2e/resilience.spec.ts
+++ b/web-rally/tests/e2e/resilience.spec.ts
@@ -116,6 +116,6 @@ test.describe('Resilience', () => {
 
     await page.goto('/rally/team-progress');
 
-    await expect(page.getByText('Os Fixes')).toBeVisible();
+    await expect(page.getByRole('main').getByText('Os Fixes')).toBeVisible();
   });
 });

--- a/web-rally/tests/e2e/staff-evaluation.spec.ts
+++ b/web-rally/tests/e2e/staff-evaluation.spec.ts
@@ -14,7 +14,6 @@ import {
   MOCK_BOOLEAN_ACTIVITY,
   MOCK_TEAM_VS_ACTIVITY,
 } from '../mocks/data';
-import { expectLoggedOutLoginCta } from './helpers/nav';
 import { seedOidcSession, STAFF_GROUPS, MANAGER_GROUPS } from './helpers/session';
 
 test.describe('Staff Evaluation Flow', () => {
@@ -395,11 +394,13 @@ test.describe('Staff Evaluation - Authentication', () => {
     // Navigate to protected page
     await page.goto(`/rally/staff-evaluation/checkpoint/${MOCK_CHECKPOINT.id}`);
 
-    // No route-level auth guard exists for this page: an unauthenticated
-    // visitor lands on the checkpoint view itself (data fails to load, so it
-    // renders its not-found state) rather than being redirected. The header's
-    // "Iniciar sessão" CTA is what actually signals the logged-out state here.
-    await expectLoggedOutLoginCta(page);
+    // layout.tsx treats "/staff-evaluation" as a staff-only path: an
+    // unauthenticated visitor is redirected to the standalone LandingGate
+    // regardless of public_access_enabled, so the app shell (navbar,
+    // hamburger) never mounts. LandingGate's own CTA is "Login Staff".
+    await expect(page.getByRole("button", { name: /login staff/i })).toBeVisible({
+      timeout: 15000,
+    });
   });
 
   test('handles expired token gracefully', async ({ page, context }) => {
@@ -476,9 +477,12 @@ test.describe('Staff Evaluation - Authentication', () => {
 
     await page.goto(`/rally/staff-evaluation/checkpoint/${MOCK_CHECKPOINT.id}`);
 
-    // An unparseable session is treated the same as no session — the header
-    // CTA reflects the logged-out state, no dedicated login screen exists.
-    await expectLoggedOutLoginCta(page);
+    // An unparseable session is treated the same as no session, and
+    // "/staff-evaluation" is a staff-only path: layout.tsx redirects to the
+    // standalone LandingGate rather than rendering the app shell.
+    await expect(page.getByRole("button", { name: /login staff/i })).toBeVisible({
+      timeout: 15000,
+    });
   });
 });
 

--- a/web-rally/tests/e2e/team-info.spec.ts
+++ b/web-rally/tests/e2e/team-info.spec.ts
@@ -58,7 +58,7 @@ test.describe('Team info', () => {
 
     await page.goto('/rally/team-info');
 
-    await expect(page.getByText('Os Fixes')).toBeVisible();
+    await expect(page.getByRole('main').getByText('Os Fixes')).toBeVisible();
     await expect(page.getByText('Capitão')).toBeVisible();
     await expect(page.getByText('Associado')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Associar a mim' })).toBeVisible();
@@ -100,7 +100,7 @@ test.describe('Team info', () => {
     const reloadPromise = page.waitForURL('**/team-info');
     await page.getByRole('button', { name: 'Associar a mim' }).click();
     await reloadPromise;
-    await expect(page.getByText('Os Fixes')).toBeVisible();
+    await expect(page.getByRole('main').getByText('Os Fixes')).toBeVisible();
   });
 
   test('failed link shows error toast', async ({ page, context }) => {
@@ -157,6 +157,6 @@ test.describe('Team info', () => {
 
     await page.goto('/rally/team-info');
 
-    await expect(page.getByText('Os Fixes')).toBeVisible();
+    await expect(page.getByRole('main').getByText('Os Fixes')).toBeVisible();
   });
 });

--- a/web-rally/tests/e2e/team-progress.spec.ts
+++ b/web-rally/tests/e2e/team-progress.spec.ts
@@ -135,7 +135,7 @@ test.describe('Team progress', () => {
 
     await page.goto('/rally/team-progress');
 
-    await expect(page.getByText('Os Fixes')).toBeVisible();
+    await expect(page.getByRole('main').getByText('Os Fixes')).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Percurso' })).toBeVisible();
     // The card follows the event's terminology; MOCK_RALLY_SETTINGS carries no
     // event_type, so it falls back to the classic rally terms ("tasca", f.).
@@ -272,6 +272,6 @@ test.describe('Team progress', () => {
 
     await page.goto('/rally/team-progress');
 
-    await expect(page.getByText('Os Fixes')).toBeVisible();
+    await expect(page.getByRole('main').getByText('Os Fixes')).toBeVisible();
   });
 });

--- a/web-rally/tests/unit/components/shared/navigation/MobileBottomNav.test.tsx
+++ b/web-rally/tests/unit/components/shared/navigation/MobileBottomNav.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MobileBottomNav } from '@/components/shared/navigation/MobileBottomNav'
+
+const { mockUseUserStore, mockUseRallySettings, mockUseTeamAuth, mockUseGuideAccess, mockPathname } =
+  vi.hoisted(() => ({
+    mockUseUserStore: vi.fn(),
+    mockUseRallySettings: vi.fn(),
+    mockUseTeamAuth: vi.fn(),
+    mockUseGuideAccess: vi.fn(),
+    mockPathname: { current: '/team-progress' },
+  }))
+
+vi.mock('@/stores/useUserStore', () => ({
+  useUserStore: (selector: (s: unknown) => unknown) => mockUseUserStore(selector),
+}))
+
+vi.mock('@/hooks/useRallySettings', () => ({
+  default: () => mockUseRallySettings(),
+}))
+
+vi.mock('@/hooks/useTeamAuth', () => ({
+  default: () => mockUseTeamAuth(),
+}))
+
+vi.mock('@/hooks/useGuideAccess', () => ({
+  default: () => mockUseGuideAccess(),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useLocation: () => ({ pathname: mockPathname.current }),
+  useNavigate: () => vi.fn(),
+  Link: ({ to, children, ...props }: { to: string; children: React.ReactNode }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+describe('MobileBottomNav', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseUserStore.mockImplementation((selector) => selector({ scopes: undefined }))
+    mockUseRallySettings.mockReturnValue({
+      settings: { show_score_mode: 'visible', show_checkpoint_map: false, badges_enabled: true },
+    })
+    mockUseGuideAccess.mockReturnValue({ showGuideFeature: false })
+  })
+
+  it('shows all 6 team destinations for a signed-in team, incl. Equipa and Definições', () => {
+    mockUseTeamAuth.mockReturnValue({
+      isAuthenticated: true,
+      team: { access_code: 'ABC-123' },
+    })
+    mockPathname.current = '/team-progress'
+
+    render(<MobileBottomNav />)
+
+    expect(screen.getByText('Progresso')).toBeInTheDocument()
+    expect(screen.getByText('Pontos')).toBeInTheDocument()
+    expect(screen.getByText('Conquistas')).toBeInTheDocument()
+    expect(screen.getByText('Equipa')).toBeInTheDocument()
+    expect(screen.getByText('Definições')).toBeInTheDocument()
+  })
+
+  it('lights the Progresso tab at /team-progress', () => {
+    mockUseTeamAuth.mockReturnValue({ isAuthenticated: true, team: undefined })
+    mockPathname.current = '/team-progress'
+
+    render(<MobileBottomNav />)
+
+    const progresso = screen.getByText('Progresso').closest('a')
+    expect(progresso).toHaveClass('rally-accent')
+  })
+
+  it('lights the Progresso tab at "/" via its alias, before the redirect lands', () => {
+    mockUseTeamAuth.mockReturnValue({ isAuthenticated: true, team: undefined })
+    mockPathname.current = '/'
+
+    render(<MobileBottomNav />)
+
+    const progresso = screen.getByText('Progresso').closest('a')
+    expect(progresso).toHaveClass('rally-accent')
+  })
+})

--- a/web-rally/tests/unit/components/shared/navigation/activeRoute.test.ts
+++ b/web-rally/tests/unit/components/shared/navigation/activeRoute.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { isNavItemActive } from '@/components/shared/navigation/activeRoute'
+
+describe('isNavItemActive', () => {
+  it('matches "/" only on an exact pathname', () => {
+    expect(isNavItemActive('/', '/')).toBe(true)
+    expect(isNavItemActive('/team-progress', '/')).toBe(false)
+    expect(isNavItemActive('/team-info', '/')).toBe(false)
+  })
+
+  it('matches a plain href exactly', () => {
+    expect(isNavItemActive('/team-progress', '/team-progress')).toBe(true)
+    expect(isNavItemActive('/scoreboard', '/team-progress')).toBe(false)
+  })
+
+  it('matches nested routes by segment prefix', () => {
+    expect(
+      isNavItemActive('/staff-evaluation/checkpoint/1', '/staff-evaluation'),
+    ).toBe(true)
+    // Not a shared segment — "/staff-evaluation-extra" must not light "/staff-evaluation".
+    expect(isNavItemActive('/staff-evaluation-extra', '/staff-evaluation')).toBe(false)
+  })
+
+  it('matches any provided alias', () => {
+    expect(isNavItemActive('/', '/team-progress', ['/'])).toBe(true)
+    expect(isNavItemActive('/checkpoints', '/team-progress', ['/'])).toBe(false)
+  })
+})

--- a/web-rally/tests/unit/hooks/useTeamAuth.test.tsx
+++ b/web-rally/tests/unit/hooks/useTeamAuth.test.tsx
@@ -6,6 +6,7 @@ import { renderHook, waitFor, act } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
 import useTeamAuth from '@/hooks/useTeamAuth'
+import { useTeamStore } from '@/stores/useTeamStore'
 import { teamLogin, getTeamById, addTeamMember, removeTeamMember } from '@/client'
 
 const TEAM_TOKEN_KEY = 'rally_team_token'
@@ -53,6 +54,11 @@ describe('useTeamAuth', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.clear()
+    // useTeamStore is a module singleton seeded once at import time; tests
+    // mutate localStorage directly, so resync it explicitly to the (now
+    // empty) storage instead of relying on a mount effect that no longer
+    // exists.
+    useTeamStore.getState().hydrate()
   })
 
   afterEach(() => {
@@ -73,6 +79,7 @@ describe('useTeamAuth', () => {
       const tokenData = { team_id: 42, team_name: 'Team Alpha' }
       localStorage.setItem(TEAM_TOKEN_KEY, 'existing-token')
       localStorage.setItem(TEAM_DATA_KEY, JSON.stringify(tokenData))
+      useTeamStore.getState().hydrate()
 
       const { result } = renderHook(() => useTeamAuth(), { wrapper: createWrapper() })
 
@@ -85,6 +92,7 @@ describe('useTeamAuth', () => {
     it('should clear invalid localStorage data on mount', async () => {
       localStorage.setItem(TEAM_TOKEN_KEY, 'token')
       localStorage.setItem(TEAM_DATA_KEY, 'invalid-json{{{')
+      useTeamStore.getState().hydrate()
 
       const { result } = renderHook(() => useTeamAuth(), { wrapper: createWrapper() })
 
@@ -155,6 +163,7 @@ describe('useTeamAuth', () => {
     it('should clear auth state and localStorage on logout', async () => {
       localStorage.setItem(TEAM_TOKEN_KEY, 'some-token')
       localStorage.setItem(TEAM_DATA_KEY, JSON.stringify({ team_id: 1, team_name: 'Team' }))
+      useTeamStore.getState().hydrate()
 
       const { result } = renderHook(() => useTeamAuth(), { wrapper: createWrapper() })
 
@@ -168,6 +177,34 @@ describe('useTeamAuth', () => {
       expect(result.current.teamData).toBeNull()
       expect(localStorage.getItem(TEAM_TOKEN_KEY)).toBeNull()
       expect(localStorage.getItem(TEAM_DATA_KEY)).toBeNull()
+    })
+  })
+
+  describe('shared store', () => {
+    it('propagates a login from one consumer to another mounted at the same time', async () => {
+      vi.mocked(teamLogin).mockResolvedValueOnce({
+        data: {
+          access_token: 'shared-token',
+          token_type: 'bearer',
+          team_id: 5,
+          team_name: 'Shared Team',
+        },
+      } as never)
+
+      const wrapper = createWrapper()
+      const a = renderHook(() => useTeamAuth(), { wrapper })
+      const b = renderHook(() => useTeamAuth(), { wrapper })
+
+      expect(a.result.current.isAuthenticated).toBe(false)
+      expect(b.result.current.isAuthenticated).toBe(false)
+
+      await act(async () => {
+        await a.result.current.login('CODE-1')
+      })
+
+      expect(a.result.current.isAuthenticated).toBe(true)
+      expect(b.result.current.isAuthenticated).toBe(true)
+      expect(b.result.current.teamData).toEqual({ team_id: 5, team_name: 'Shared Team' })
     })
   })
 
@@ -189,6 +226,7 @@ describe('useTeamAuth', () => {
       const tokenData = { team_id: 42, team_name: 'Team Alpha' }
       localStorage.setItem(TEAM_TOKEN_KEY, 'existing-token')
       localStorage.setItem(TEAM_DATA_KEY, JSON.stringify(tokenData))
+      useTeamStore.getState().hydrate()
       vi.mocked(getTeamById).mockResolvedValueOnce({
         data: { id: 42, name: 'Team Alpha', members: [] },
       } as never)
@@ -233,6 +271,7 @@ describe('useTeamAuth', () => {
       const tokenData = { team_id: 7, team_name: 'Team Beta' }
       localStorage.setItem(TEAM_TOKEN_KEY, 'existing-token')
       localStorage.setItem(TEAM_DATA_KEY, JSON.stringify(tokenData))
+      useTeamStore.getState().hydrate()
       vi.mocked(getTeamById).mockResolvedValue({
         data: { id: 7, name: 'Team Beta', members: [] },
       } as never)
@@ -277,6 +316,7 @@ describe('useTeamAuth', () => {
       const tokenData = { team_id: 9, team_name: 'Team Gamma' }
       localStorage.setItem(TEAM_TOKEN_KEY, 'existing-token')
       localStorage.setItem(TEAM_DATA_KEY, JSON.stringify(tokenData))
+      useTeamStore.getState().hydrate()
       vi.mocked(getTeamById).mockResolvedValue({
         data: { id: 9, name: 'Team Gamma', members: [] },
       } as never)

--- a/web-rally/tests/unit/pages/layout.test.tsx
+++ b/web-rally/tests/unit/pages/layout.test.tsx
@@ -2,16 +2,28 @@ import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import MainLayout from '@/pages/layout';
 
-const { mockUseUserStore, mockUseStaffLogin, mockUseRallySettings, mockUseDocumentBranding } =
-  vi.hoisted(() => ({
-    mockUseUserStore: vi.fn(),
-    mockUseStaffLogin: vi.fn(),
-    mockUseRallySettings: vi.fn(),
-    mockUseDocumentBranding: vi.fn(),
-  }));
+const {
+  mockUseUserStore,
+  mockUseTeamStore,
+  mockUseStaffLogin,
+  mockUseRallySettings,
+  mockUseDocumentBranding,
+  mockPathname,
+} = vi.hoisted(() => ({
+  mockUseUserStore: vi.fn(),
+  mockUseTeamStore: vi.fn(),
+  mockUseStaffLogin: vi.fn(),
+  mockUseRallySettings: vi.fn(),
+  mockUseDocumentBranding: vi.fn(),
+  mockPathname: { current: '/' },
+}));
 
 vi.mock('@/stores/useUserStore', () => ({
   useUserStore: (selector: (s: unknown) => unknown) => mockUseUserStore(selector),
+}));
+
+vi.mock('@/stores/useTeamStore', () => ({
+  useTeamStore: (selector: (s: unknown) => unknown) => mockUseTeamStore(selector),
 }));
 
 vi.mock('@/hooks/useLoginLink', () => ({
@@ -52,6 +64,10 @@ vi.mock('@/components/landing/LandingGate', () => ({
 
 vi.mock('@tanstack/react-router', () => ({
   Outlet: () => <div data-testid="outlet" />,
+  useLocation: (opts?: { select?: (s: { pathname: string }) => unknown }) => {
+    const state = { pathname: mockPathname.current };
+    return opts?.select ? opts.select(state) : state;
+  },
 }));
 
 vi.mock('@/components/themes', () => ({
@@ -63,6 +79,8 @@ describe('MainLayout', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseStaffLogin.mockReturnValue(vi.fn());
+    // Default: no team session. Individual tests override via mockUseTeamStore.
+    mockUseTeamStore.mockImplementation((selector) => selector({ isAuthenticated: false }));
   });
 
   it('renders the LandingGate when unauthenticated, public access disabled, and not on a public path', () => {
@@ -73,7 +91,7 @@ describe('MainLayout', () => {
       settings: { public_access_enabled: false },
       isLoading: false,
     });
-    window.history.pushState({}, '', '/rally/private-page');
+    mockPathname.current = '/private-page';
 
     render(<MainLayout />);
     expect(screen.getByTestId('landing-gate')).toBeInTheDocument();
@@ -88,7 +106,7 @@ describe('MainLayout', () => {
       settings: { public_access_enabled: false },
       isLoading: false,
     });
-    window.history.pushState({}, '', '/rally/');
+    mockPathname.current = '/';
 
     render(<MainLayout />);
     expect(screen.getByTestId('navbar')).toBeInTheDocument();
@@ -106,7 +124,7 @@ describe('MainLayout', () => {
       settings: { public_access_enabled: true },
       isLoading: false,
     });
-    window.history.pushState({}, '', '/rally/');
+    mockPathname.current = '/';
 
     render(<MainLayout />);
     expect(screen.getByTestId('outlet')).toBeInTheDocument();
@@ -117,9 +135,37 @@ describe('MainLayout', () => {
       selector({ sub: undefined, sessionLoading: false }),
     );
     mockUseRallySettings.mockReturnValue({ settings: undefined, isLoading: true });
-    window.history.pushState({}, '', '/rally/');
+    mockPathname.current = '/';
 
     render(<MainLayout />);
     expect(screen.getByText('A carregar')).toBeInTheDocument();
+  });
+
+  it('renders the full app shell for a team-only session even when public access is disabled', () => {
+    mockUseUserStore.mockImplementation((selector) =>
+      selector({ sub: undefined, sessionLoading: false }),
+    );
+    mockUseTeamStore.mockImplementation((selector) => selector({ isAuthenticated: true }));
+    mockUseRallySettings.mockReturnValue({
+      settings: { public_access_enabled: false },
+      isLoading: false,
+    });
+    mockPathname.current = '/team-info';
+
+    render(<MainLayout />);
+    expect(screen.getByTestId('outlet')).toBeInTheDocument();
+    expect(screen.queryByTestId('landing-gate')).not.toBeInTheDocument();
+  });
+
+  it('does not block access when settings fail to load (undefined, not loading)', () => {
+    mockUseUserStore.mockImplementation((selector) =>
+      selector({ sub: undefined, sessionLoading: false }),
+    );
+    mockUseRallySettings.mockReturnValue({ settings: undefined, isLoading: false });
+    mockPathname.current = '/private-page';
+
+    render(<MainLayout />);
+    expect(screen.getByTestId('outlet')).toBeInTheDocument();
+    expect(screen.queryByTestId('landing-gate')).not.toBeInTheDocument();
   });
 });

--- a/web-rally/tests/unit/services/client.test.ts
+++ b/web-rally/tests/unit/services/client.test.ts
@@ -71,6 +71,37 @@ describe("client.ts", () => {
       expect(localStorage.getItem("rally_team_data")).toBeNull();
     });
 
+    it("keeps the team session on a 500 (server hiccup, not a dead token)", async () => {
+      localStorage.setItem("rally_team_token", "still-good-jwt");
+      localStorage.setItem("rally_team_data", '{"team_id":1,"team_name":"T"}');
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+
+      const { refreshTeamToken } = await import("@/services/client");
+      const result = await refreshTeamToken();
+
+      expect(result).toBeUndefined();
+      expect(localStorage.getItem("rally_team_token")).toBe("still-good-jwt");
+      expect(localStorage.getItem("rally_team_data")).toBe('{"team_id":1,"team_name":"T"}');
+    });
+
+    it("keeps the team session on a network error (offline/timeout)", async () => {
+      localStorage.setItem("rally_team_token", "still-good-jwt");
+      localStorage.setItem("rally_team_data", '{"team_id":1,"team_name":"T"}');
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockRejectedValue(new TypeError("Failed to fetch")),
+      );
+
+      const { refreshTeamToken } = await import("@/services/client");
+      const result = await refreshTeamToken();
+
+      expect(result).toBeUndefined();
+      expect(localStorage.getItem("rally_team_token")).toBe("still-good-jwt");
+      expect(localStorage.getItem("rally_team_data")).toBe('{"team_id":1,"team_name":"T"}');
+    });
+
     it("returns undefined when there is no team token", async () => {
       const { refreshTeamToken } = await import("@/services/client");
       const result = await refreshTeamToken();


### PR DESCRIPTION
This pull request improves navigation behavior and team authentication handling, especially for teams signing in without a user account. It introduces a new way to determine active navigation tabs, ensures seamless team session detection, and refines public path access and redirects. The most important changes are grouped below.

**Navigation and Active Tab Logic:**

* Added a new utility function `isNavItemActive` to consistently determine when a navigation tab should be highlighted as active, supporting aliases and nested routes. This logic is now used throughout navigation components, replacing direct path comparisons. [[1]](diffhunk://#diff-94953430847386b9de33ac24738e8a5f97e5bda943ed7b6e315e45fbc60ec281R1-R22) [[2]](diffhunk://#diff-2f934bf4a7f4b97cfef90cb6f7925fbafbc86032f2a9c34181465a086b0bffcdR18) [[3]](diffhunk://#diff-2f934bf4a7f4b97cfef90cb6f7925fbafbc86032f2a9c34181465a086b0bffcdL118-R132) [[4]](diffhunk://#diff-2f934bf4a7f4b97cfef90cb6f7925fbafbc86032f2a9c34181465a086b0bffcdL135-R149) [[5]](diffhunk://#diff-348f1b63b6e5d04a02bcf7e9ec712fe946ccae54daec559c25d75b0098efa2aaR3) [[6]](diffhunk://#diff-348f1b63b6e5d04a02bcf7e9ec712fe946ccae54daec559c25d75b0098efa2aaL59-R60) [[7]](diffhunk://#diff-348f1b63b6e5d04a02bcf7e9ec712fe946ccae54daec559c25d75b0098efa2aaL84-R85) [[8]](diffhunk://#diff-348f1b63b6e5d04a02bcf7e9ec712fe946ccae54daec559c25d75b0098efa2aaL230-R233) [[9]](diffhunk://#diff-348f1b63b6e5d04a02bcf7e9ec712fe946ccae54daec559c25d75b0098efa2aaL381-R384)
* Updated `NavItem` to support an `aliases` property, allowing multiple paths to activate the same tab (e.g., `/` and `/team-progress`). [[1]](diffhunk://#diff-2f934bf4a7f4b97cfef90cb6f7925fbafbc86032f2a9c34181465a086b0bffcdR34-R35) [[2]](diffhunk://#diff-2f934bf4a7f4b97cfef90cb6f7925fbafbc86032f2a9c34181465a086b0bffcdL74-R86)

**Team Authentication and Session Handling:**

* Refactored `useTeamAuth` to use a centralized store (`useTeamStore`) for team authentication state, ensuring immediate session availability and eliminating unnecessary loading windows. [[1]](diffhunk://#diff-2d3907f38bbfb98b807604335fdc14928c6850a69712a9742007a103f6a9a224L1-R1) [[2]](diffhunk://#diff-2d3907f38bbfb98b807604335fdc14928c6850a69712a9742007a103f6a9a224L15-R19) [[3]](diffhunk://#diff-2d3907f38bbfb98b807604335fdc14928c6850a69712a9742007a103f6a9a224L34-R45) [[4]](diffhunk://#diff-2d3907f38bbfb98b807604335fdc14928c6850a69712a9742007a103f6a9a224L91-R83) [[5]](diffhunk://#diff-2d3907f38bbfb98b807604335fdc14928c6850a69712a9742007a103f6a9a224L131-R121) [[6]](diffhunk://#diff-2d3907f38bbfb98b807604335fdc14928c6850a69712a9742007a103f6a9a224L145-R134)
* Updated `UserMenu` to display the team's identity and session management options when a team is authenticated without a user account, treating team sessions as first-class identities. [[1]](diffhunk://#diff-8a78bdb2aaf083ffca2db1ae6b5dc3653a5d9186b3567e789ecf1d929d25ac9dR2-R21) [[2]](diffhunk://#diff-8a78bdb2aaf083ffca2db1ae6b5dc3653a5d9186b3567e789ecf1d929d25ac9dR34-R80)

**Public Path and Access Control Improvements:**

* Expanded the list of public paths and improved logic to ensure that public and team-specific routes remain accessible even if global public access is disabled or settings are loading. [[1]](diffhunk://#diff-a39d01eb92824c5ecb91ee27849d85e101a155ea2ee00fd18816cccf970f60d8L12-R13) [[2]](diffhunk://#diff-a39d01eb92824c5ecb91ee27849d85e101a155ea2ee00fd18816cccf970f60d8R23) [[3]](diffhunk://#diff-a39d01eb92824c5ecb91ee27849d85e101a155ea2ee00fd18816cccf970f60d8L30-R53)

**Routing and Redirects:**

* Added a `beforeLoad` redirect to the `/` route so that authenticated teams are immediately routed to `/team-progress`, preventing a flash of the marketing landing or an unlit nav bar. [[1]](diffhunk://#diff-3a6559518657b6d3e582239de5ced007af113b72a63e852abe0399e5d7efb44fL1-R9) [[2]](diffhunk://#diff-3a6559518657b6d3e582239de5ced007af113b72a63e852abe0399e5d7efb44fR30-R39)

These changes collectively make navigation more intuitive for teams, improve session handling, and ensure a smoother user experience across authentication states.