### PR TITLE
feat: rich clue media — QR codes, Spotify embeds, and links per checkpoint

### DIFF
--- a/api-rally/alembic/versions/0041_checkpoint_media_rich_kinds.py
+++ b/api-rally/alembic/versions/0041_checkpoint_media_rich_kinds.py
@@ -1,0 +1,72 @@
+"""add rich clue media kinds to checkpoint_media
+
+Checkpoint media only ever meant "photo" or "fun fact" — the real event
+planning documents this app is modeled on also want a QR code (scan for a
+riddle/challenge), a Spotify link (a song to listen to on site), or a plain
+external link, attached to a post alongside photos, all in the same ordered
+list.
+
+Adds three new ``media_kind`` enum values (``qr``, ``spotify``, ``link``)
+and three new nullable columns on ``checkpoint_media``:
+
+- ``content_url``: the external URL for ``spotify``/``link`` — kept
+  separate from ``image_url`` because it is never an R2-uploaded asset and
+  must never be passed to the storage deleter.
+- ``content_text``: the raw payload a ``qr`` row encodes.
+- ``title``: a short optional label shown above a ``spotify``/``link`` card.
+
+``caption``/``order`` stay shared across every kind, matching the existing
+photo/fun_fact rows.
+
+This is the first migration in this repo that adds values to an existing
+Postgres enum type. On Postgres 12+, ``ALTER TYPE ... ADD VALUE`` is allowed
+inside a transaction as long as the new value isn't *used* in that same
+transaction — which this migration never does, so no special
+non-transactional handling is needed here.
+
+``downgrade()`` only drops the three new columns; Postgres cannot cheaply
+remove enum values (would require rebuilding the type and every column that
+uses it), so a downgrade leaves the three enum values in place — any row
+still using them would otherwise be unrepresentable.
+
+Revision ID: 0041
+Revises: 0040
+Create Date: 2026-08-10
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+from alembic.migration_utils import add_missing_columns, drop_present_columns
+from app.core.config import settings
+
+# revision identifiers, used by Alembic.
+revision: str = "0041"
+down_revision: str | None = "0040"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = settings.SCHEMA_NAME
+TABLE = "checkpoint_media"
+ENUM = "media_kind"
+NEW_KINDS = ("qr", "spotify", "link")
+COLUMNS = {
+    "content_url": sa.Column("content_url", sa.String(length=500), nullable=True),
+    "content_text": sa.Column("content_text", sa.Text(), nullable=True),
+    "title": sa.Column("title", sa.String(length=200), nullable=True),
+}
+
+
+def upgrade() -> None:
+    # `ALTER TYPE ... ADD VALUE` takes a string literal, not a bindable
+    # parameter — safe to interpolate directly since NEW_KINDS is a fixed,
+    # hardcoded tuple, never user input.
+    for kind in NEW_KINDS:
+        op.execute(f'ALTER TYPE "{SCHEMA}"."{ENUM}" ADD VALUE IF NOT EXISTS \'{kind}\'')
+    add_missing_columns(TABLE, COLUMNS, SCHEMA)
+
+
+def downgrade() -> None:
+    drop_present_columns(TABLE, COLUMNS, SCHEMA)

--- a/api-rally/app/api/api_v1/checkpoint_media.py
+++ b/api-rally/app/api/api_v1/checkpoint_media.py
@@ -1,6 +1,7 @@
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import crud
@@ -122,13 +123,26 @@ class CheckpointMediaController:
         kind: Annotated[MediaKind, Form()],
         caption: Annotated[str | None, Form()] = None,
         order: Annotated[int, Form()] = 0,
+        title: Annotated[str | None, Form()] = None,
+        content_url: Annotated[str | None, Form()] = None,
+        content_text: Annotated[str | None, Form()] = None,
         image: Annotated[UploadFile | None, File()] = None,
     ) -> CheckpointMediaResponse:
         await self._get_checkpoint_or_404(db, checkpoint_id)
         image_url = await CheckpointMediaService.upload_image_if_provided(
             image, checkpoint_id=checkpoint_id
         )
-        obj_in = CheckpointMediaCreate(kind=kind, caption=caption, order=order)
+        try:
+            obj_in = CheckpointMediaCreate(
+                kind=kind,
+                caption=caption,
+                order=order,
+                title=title,
+                content_url=content_url or None,
+                content_text=content_text,
+            )
+        except ValidationError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
         created = await crud_media.create(
             db, checkpoint_id=checkpoint_id, obj_in=obj_in, image_url=image_url
         )
@@ -140,6 +154,9 @@ class CheckpointMediaController:
         db: Annotated[AsyncSession, Depends(deps.get_db)],
         caption: Annotated[str | None, Form()] = None,
         order: Annotated[int | None, Form()] = None,
+        title: Annotated[str | None, Form()] = None,
+        content_url: Annotated[str | None, Form()] = None,
+        content_text: Annotated[str | None, Form()] = None,
         image: Annotated[UploadFile | None, File()] = None,
     ) -> CheckpointMediaResponse:
         db_obj = await crud_media.get(db, id=media_id)
@@ -148,8 +165,17 @@ class CheckpointMediaController:
         image_url = await CheckpointMediaService.upload_image_if_provided(
             image, checkpoint_id=db_obj.checkpoint_id
         )
-        obj_in = CheckpointMediaUpdate(caption=caption, order=order)
-        updated = await crud_media.update(db, db_obj=db_obj, obj_in=obj_in, image_url=image_url)
+        try:
+            obj_in = CheckpointMediaUpdate(
+                caption=caption,
+                order=order,
+                title=title,
+                content_url=content_url or None,
+                content_text=content_text,
+            )
+            updated = await crud_media.update(db, db_obj=db_obj, obj_in=obj_in, image_url=image_url)
+        except (ValidationError, ValueError) as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
         return CheckpointMediaResponse.model_validate(updated)
 
     async def delete_checkpoint_media(

--- a/api-rally/app/crud/crud_checkpoint_media.py
+++ b/api-rally/app/crud/crud_checkpoint_media.py
@@ -2,7 +2,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.checkpoint_media import CheckpointMedia
-from app.schemas.checkpoint_media import CheckpointMediaCreate, CheckpointMediaUpdate
+from app.schemas.checkpoint_media import (
+    CheckpointMediaCreate,
+    CheckpointMediaUpdate,
+    validate_update_against_kind,
+)
 from app.services.storage import storage_client
 
 
@@ -35,6 +39,9 @@ class CRUDCheckpointMedia:
             caption=obj_in.caption,
             order=obj_in.order,
             image_url=image_url,
+            content_url=str(obj_in.content_url) if obj_in.content_url else None,
+            content_text=obj_in.content_text,
+            title=obj_in.title,
         )
         db.add(db_obj)
         await db.commit()
@@ -49,10 +56,17 @@ class CRUDCheckpointMedia:
         obj_in: CheckpointMediaUpdate,
         image_url: str | None = None,
     ) -> CheckpointMedia:
+        validate_update_against_kind(obj_in, kind=db_obj.kind)
         if obj_in.caption is not None:
             db_obj.caption = obj_in.caption
         if obj_in.order is not None:
             db_obj.order = obj_in.order
+        if obj_in.title is not None:
+            db_obj.title = obj_in.title
+        if obj_in.content_url is not None:
+            db_obj.content_url = str(obj_in.content_url)
+        if obj_in.content_text is not None:
+            db_obj.content_text = obj_in.content_text
         if image_url is not None:
             if db_obj.image_url:
                 storage_client.delete_image(db_obj.image_url)

--- a/api-rally/app/models/checkpoint_media.py
+++ b/api-rally/app/models/checkpoint_media.py
@@ -15,6 +15,13 @@ if TYPE_CHECKING:
 class MediaKind(str, enum.Enum):
     photo = "photo"
     fun_fact = "fun_fact"
+    # Rich clue media: QR code, a Spotify embed, or a plain external link.
+    # TODO: a `document`/PDF kind would need image_upload.py extended with
+    # an ALLOWED_DOCUMENT_CONTENT_TYPES set + a `document_url` column — no
+    # confirmed use case for it yet, so left out of this pass.
+    qr = "qr"
+    spotify = "spotify"
+    link = "link"
 
 
 class CheckpointMedia(Base):
@@ -32,7 +39,14 @@ class CheckpointMedia(Base):
         SAEnum(MediaKind, name="media_kind", schema=settings.SCHEMA_NAME),
         nullable=False,
     )
+    # `photo` only — an R2-uploaded asset, deleted from storage on replace/delete.
     image_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    # `spotify`/`link` only — an external URL, never touches R2 storage.
+    content_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    # `qr` only — the raw payload (URL or free text) the QR code encodes.
+    content_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # `spotify`/`link` only — short optional label shown above the embed/card.
+    title: Mapped[str | None] = mapped_column(String(200), nullable=True)
     caption: Mapped[str | None] = mapped_column(Text, nullable=True)
     order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 

--- a/api-rally/app/schemas/checkpoint_media.py
+++ b/api-rally/app/schemas/checkpoint_media.py
@@ -1,21 +1,139 @@
-from pydantic import BaseModel, ConfigDict
+import re
+
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from app.models.checkpoint_media import MediaKind
+
+# Only the canonical Spotify web-player domain — this is what the embed
+# iframe consumes (open.spotify.com/embed/...), so anything else (short
+# links, spotify.com without "open", a lookalike domain) is rejected rather
+# than trusted to resolve into something safe to embed later.
+SPOTIFY_URL_PATTERN = re.compile(r"^https://open\.spotify\.com/")
+
+# `link` accepts any http(s) URL — validated with a plain scheme check
+# rather than Pydantic's `AnyHttpUrl` type, since these fields arrive as
+# plain multipart Form() strings (not JSON body fields FastAPI can coerce
+# on the way in), and a manually-constructed schema in handler code doesn't
+# get FastAPI's automatic body-validation-to-422 conversion either way — the
+# handler already wraps construction in a try/except ValidationError/ValueError.
+HTTP_URL_PATTERN = re.compile(r"^https?://", re.IGNORECASE)
+
+QR_CONTENT_MAX_LENGTH = 2000  # practical payload ceiling for a scannable level-H QR
+
+# Which of the kind-specific fields each MediaKind is allowed to carry.
+# Anything a kind doesn't list here is rejected outright rather than
+# silently dropped — an admin who fills in the wrong field would otherwise
+# have no way to notice it was discarded.
+_ALLOWED_FIELDS_BY_KIND: dict[MediaKind, frozenset[str]] = {
+    MediaKind.photo: frozenset(),
+    MediaKind.fun_fact: frozenset(),
+    MediaKind.qr: frozenset({"content_text"}),
+    MediaKind.spotify: frozenset({"content_url", "title"}),
+    MediaKind.link: frozenset({"content_url", "title"}),
+}
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _reject_fields_not_allowed_for_kind(
+    *, kind: MediaKind, content_url: str | None, content_text: str | None, title: str | None
+) -> None:
+    """Reject any kind-specific field a `kind` isn't allowed to carry.
+
+    Shared by create (full validation) and update (rejection only — a
+    partial update must not re-demand presence of fields it isn't touching).
+    """
+    allowed = _ALLOWED_FIELDS_BY_KIND[kind]
+    if content_url is not None and "content_url" not in allowed:
+        raise ValueError(f"{kind.value} media does not use content_url")
+    if content_text is not None and "content_text" not in allowed:
+        raise ValueError(f"{kind.value} media does not use content_text")
+    if title is not None and "title" not in allowed:
+        raise ValueError(f"{kind.value} media does not use title")
+
+
+def _validate_required_fields_for_kind(
+    *, kind: MediaKind, caption: str | None, content_url: str | None, content_text: str | None
+) -> None:
+    """Full presence/shape validation for a brand-new row (create only)."""
+    if kind == MediaKind.qr:
+        _require(bool(content_text and content_text.strip()), "QR code requires content_text")
+        _require(
+            len(content_text or "") <= QR_CONTENT_MAX_LENGTH,
+            f"QR content_text must be at most {QR_CONTENT_MAX_LENGTH} characters",
+        )
+    elif kind == MediaKind.spotify:
+        _require(bool(content_url), "Spotify media requires content_url")
+        _require(
+            bool(content_url and SPOTIFY_URL_PATTERN.match(content_url)),
+            "Spotify content_url must be an open.spotify.com link",
+        )
+    elif kind == MediaKind.link:
+        _require(bool(content_url), "Link media requires content_url")
+        _require(
+            bool(content_url and HTTP_URL_PATTERN.match(content_url)),
+            "Link content_url must be an http(s) URL",
+        )
+    elif kind == MediaKind.fun_fact:
+        _require(bool(caption and caption.strip()), "Fun fact requires a caption")
 
 
 class CheckpointMediaBase(BaseModel):
     kind: MediaKind
     caption: str | None = None
     order: int = 0
+    title: str | None = None
+    content_url: str | None = None
+    content_text: str | None = None
 
 
 class CheckpointMediaCreate(CheckpointMediaBase):
-    pass
+    @model_validator(mode="after")
+    def _validate_kind_shape(self) -> "CheckpointMediaCreate":
+        _reject_fields_not_allowed_for_kind(
+            kind=self.kind,
+            content_url=self.content_url,
+            content_text=self.content_text,
+            title=self.title,
+        )
+        _validate_required_fields_for_kind(
+            kind=self.kind,
+            caption=self.caption,
+            content_url=self.content_url,
+            content_text=self.content_text,
+        )
+        return self
 
 
 class CheckpointMediaUpdate(BaseModel):
+    """No `kind` here — a row's kind never changes after creation. Rejection
+    of fields that don't belong to the row's existing kind happens in the
+    CRUD layer (`validate_update_against_kind`), which knows that kind;
+    this schema only shapes the incoming payload.
+    """
+
     caption: str | None = None
     order: int | None = None
+    title: str | None = None
+    content_url: str | None = None
+    content_text: str | None = None
+
+
+def validate_update_against_kind(update: CheckpointMediaUpdate, *, kind: MediaKind) -> None:
+    """Reject an update that sets a field the row's kind doesn't use.
+
+    Called from the CRUD layer, which is the only place that knows the
+    row's persisted `kind` (the update payload itself never carries one).
+    """
+    _reject_fields_not_allowed_for_kind(
+        kind=kind,
+        content_url=update.content_url,
+        content_text=update.content_text,
+        title=update.title,
+    )
 
 
 class CheckpointMediaResponse(CheckpointMediaBase):

--- a/api-rally/app/tests/api/test_checkpoint_media.py
+++ b/api-rally/app/tests/api/test_checkpoint_media.py
@@ -202,3 +202,135 @@ async def test_delete_media_404_if_missing(pg_session, pg_client, as_admin):
     resp = pg_client.delete("/api/rally/v1/checkpoint/media/999999")
 
     assert resp.status_code == 404
+
+
+async def test_create_media_qr_success(pg_session, pg_client, as_admin):
+    await _make_event(pg_session)
+    checkpoint = await _make_checkpoint(pg_session)
+
+    resp = pg_client.post(
+        f"/api/rally/v1/checkpoint/{checkpoint.id}/media",
+        data={"kind": "qr", "content_text": "https://example.com/riddle"},
+    )
+
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["content_text"] == "https://example.com/riddle"
+
+
+async def test_create_media_qr_rejects_empty_content(pg_session, pg_client, as_admin):
+    await _make_event(pg_session)
+    checkpoint = await _make_checkpoint(pg_session)
+
+    resp = pg_client.post(
+        f"/api/rally/v1/checkpoint/{checkpoint.id}/media",
+        data={"kind": "qr"},
+    )
+
+    assert resp.status_code == 422
+
+
+async def test_create_media_spotify_success(pg_session, pg_client, as_admin):
+    await _make_event(pg_session)
+    checkpoint = await _make_checkpoint(pg_session)
+
+    resp = pg_client.post(
+        f"/api/rally/v1/checkpoint/{checkpoint.id}/media",
+        data={
+            "kind": "spotify",
+            "content_url": "https://open.spotify.com/track/abc123",
+            "title": "Ouve isto",
+        },
+    )
+
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["content_url"] == "https://open.spotify.com/track/abc123"
+    assert body["title"] == "Ouve isto"
+
+
+async def test_create_media_spotify_rejects_invalid_domain(pg_session, pg_client, as_admin):
+    await _make_event(pg_session)
+    checkpoint = await _make_checkpoint(pg_session)
+
+    resp = pg_client.post(
+        f"/api/rally/v1/checkpoint/{checkpoint.id}/media",
+        data={"kind": "spotify", "content_url": "https://evil.com/spotify"},
+    )
+
+    assert resp.status_code == 422
+
+
+async def test_create_media_link_success(pg_session, pg_client, as_admin):
+    await _make_event(pg_session)
+    checkpoint = await _make_checkpoint(pg_session)
+
+    resp = pg_client.post(
+        f"/api/rally/v1/checkpoint/{checkpoint.id}/media",
+        data={"kind": "link", "content_url": "https://example.com"},
+    )
+
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["content_url"] == "https://example.com"
+
+
+async def test_create_media_link_rejects_non_http_scheme(pg_session, pg_client, as_admin):
+    await _make_event(pg_session)
+    checkpoint = await _make_checkpoint(pg_session)
+
+    resp = pg_client.post(
+        f"/api/rally/v1/checkpoint/{checkpoint.id}/media",
+        data={"kind": "link", "content_url": "javascript:alert(1)"},
+    )
+
+    assert resp.status_code == 422
+
+
+async def test_create_media_photo_rejects_content_url_field(pg_session, pg_client, as_admin):
+    await _make_event(pg_session)
+    checkpoint = await _make_checkpoint(pg_session)
+
+    resp = pg_client.post(
+        f"/api/rally/v1/checkpoint/{checkpoint.id}/media",
+        data={"kind": "photo", "content_url": "https://example.com"},
+    )
+
+    assert resp.status_code == 422
+
+
+async def test_update_media_rejects_field_from_a_different_kind(pg_session, pg_client, as_admin):
+    await _make_event(pg_session)
+    checkpoint = await _make_checkpoint(pg_session)
+    media = await crud_media.create(
+        pg_session,
+        checkpoint_id=checkpoint.id,
+        obj_in=CheckpointMediaCreate(kind=MediaKind.qr, content_text="original"),
+    )
+
+    resp = pg_client.put(
+        f"/api/rally/v1/checkpoint/media/{media.id}",
+        data={"content_url": "https://example.com"},
+    )
+
+    assert resp.status_code == 422
+
+
+async def test_list_media_includes_new_fields(pg_session, pg_client, as_admin):
+    await _make_event(pg_session)
+    checkpoint = await _make_checkpoint(pg_session)
+    await crud_media.create(
+        pg_session,
+        checkpoint_id=checkpoint.id,
+        obj_in=CheckpointMediaCreate(
+            kind=MediaKind.spotify,
+            content_url="https://open.spotify.com/track/xyz",
+            title="Faixa",
+        ),
+    )
+
+    resp = pg_client.get(f"/api/rally/v1/checkpoint/{checkpoint.id}/media")
+
+    assert resp.status_code == 200
+    item = resp.json()[0]
+    assert item["content_url"] == "https://open.spotify.com/track/xyz"
+    assert item["title"] == "Faixa"
+    assert item["content_text"] is None

--- a/api-rally/app/tests/crud/test_crud_checkpoint_media.py
+++ b/api-rally/app/tests/crud/test_crud_checkpoint_media.py
@@ -6,6 +6,8 @@ out of scope here; everything else (DB writes) is real.
 
 from unittest.mock import patch
 
+import pytest
+
 from app.crud.crud_checkpoint import checkpoint as crud_checkpoint
 from app.crud.crud_checkpoint_media import checkpoint_media as crud_media
 from app.models.checkpoint_media import MediaKind
@@ -119,3 +121,87 @@ async def test_update_with_no_changes_leaves_fields_untouched(pg_session) -> Non
     assert updated.caption == "Original"
     assert updated.order == 0
     assert updated.image_url == "https://cdn.example.com/original.png"
+
+
+async def test_create_qr_persists_content_text(pg_session) -> None:
+    await _make_event(pg_session)
+    checkpoint = await _make_checkpoint(pg_session)
+
+    media = await crud_media.create(
+        pg_session,
+        checkpoint_id=checkpoint.id,
+        obj_in=CheckpointMediaCreate(kind=MediaKind.qr, content_text="https://example.com/riddle"),
+    )
+
+    assert media.kind == MediaKind.qr
+    assert media.content_text == "https://example.com/riddle"
+    assert media.image_url is None
+    assert media.content_url is None
+
+
+async def test_create_spotify_persists_content_url_and_title(pg_session) -> None:
+    await _make_event(pg_session)
+    checkpoint = await _make_checkpoint(pg_session)
+
+    media = await crud_media.create(
+        pg_session,
+        checkpoint_id=checkpoint.id,
+        obj_in=CheckpointMediaCreate(
+            kind=MediaKind.spotify,
+            content_url="https://open.spotify.com/track/abc123",
+            title="Ouve isto",
+        ),
+    )
+
+    assert media.content_url == "https://open.spotify.com/track/abc123"
+    assert media.title == "Ouve isto"
+
+
+async def test_create_link_persists_content_url(pg_session) -> None:
+    await _make_event(pg_session)
+    checkpoint = await _make_checkpoint(pg_session)
+
+    media = await crud_media.create(
+        pg_session,
+        checkpoint_id=checkpoint.id,
+        obj_in=CheckpointMediaCreate(kind=MediaKind.link, content_url="https://example.com"),
+    )
+
+    assert media.content_url == "https://example.com"
+
+
+async def test_update_link_content_url_does_not_touch_image_storage(pg_session) -> None:
+    await _make_event(pg_session)
+    checkpoint = await _make_checkpoint(pg_session)
+    media = await crud_media.create(
+        pg_session,
+        checkpoint_id=checkpoint.id,
+        obj_in=CheckpointMediaCreate(kind=MediaKind.link, content_url="https://example.com/old"),
+    )
+
+    with patch("app.crud.crud_checkpoint_media.storage_client.delete_image") as mock_delete:
+        updated = await crud_media.update(
+            pg_session,
+            db_obj=media,
+            obj_in=CheckpointMediaUpdate(content_url="https://example.com/new"),
+        )
+
+    mock_delete.assert_not_called()
+    assert updated.content_url == "https://example.com/new"
+
+
+async def test_update_qr_rejects_field_from_a_different_kind(pg_session) -> None:
+    await _make_event(pg_session)
+    checkpoint = await _make_checkpoint(pg_session)
+    media = await crud_media.create(
+        pg_session,
+        checkpoint_id=checkpoint.id,
+        obj_in=CheckpointMediaCreate(kind=MediaKind.qr, content_text="original text"),
+    )
+
+    with pytest.raises(ValueError, match="content_url"):
+        await crud_media.update(
+            pg_session,
+            db_obj=media,
+            obj_in=CheckpointMediaUpdate(content_url="https://example.com"),
+        )

--- a/api-rally/app/tests/unit/schemas/test_checkpoint_media_schema.py
+++ b/api-rally/app/tests/unit/schemas/test_checkpoint_media_schema.py
@@ -1,0 +1,120 @@
+"""Unit tests for CheckpointMedia schema validators — pure, no DB needed."""
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.checkpoint_media import MediaKind
+from app.schemas.checkpoint_media import (
+    QR_CONTENT_MAX_LENGTH,
+    CheckpointMediaCreate,
+    CheckpointMediaUpdate,
+    validate_update_against_kind,
+)
+
+
+class TestCheckpointMediaCreateValidation:
+    def test_qr_requires_content_text(self) -> None:
+        with pytest.raises(ValidationError, match="content_text"):
+            CheckpointMediaCreate(kind=MediaKind.qr)
+
+    def test_qr_rejects_content_text_over_max_length(self) -> None:
+        with pytest.raises(ValidationError, match="2000"):
+            CheckpointMediaCreate(kind=MediaKind.qr, content_text="x" * (QR_CONTENT_MAX_LENGTH + 1))
+
+    def test_qr_accepts_content_text_at_max_length(self) -> None:
+        media = CheckpointMediaCreate(kind=MediaKind.qr, content_text="x" * QR_CONTENT_MAX_LENGTH)
+        assert media.content_text is not None
+        assert len(media.content_text) == QR_CONTENT_MAX_LENGTH
+
+    def test_qr_rejects_content_url(self) -> None:
+        with pytest.raises(ValidationError, match="content_url"):
+            CheckpointMediaCreate(
+                kind=MediaKind.qr, content_text="payload", content_url="https://example.com"
+            )
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://open.spotify.com/track/abc123",
+            "https://open.spotify.com/playlist/xyz",
+        ],
+    )
+    def test_spotify_accepts_open_spotify_com(self, url: str) -> None:
+        media = CheckpointMediaCreate(kind=MediaKind.spotify, content_url=url)
+        assert media.content_url == url
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://evil.com/spotify",
+            "https://spotify.com/track/abc123",  # missing "open." subdomain
+            "http://open.spotify.com/track/abc123",  # not https
+        ],
+    )
+    def test_spotify_rejects_non_open_spotify_domain(self, url: str) -> None:
+        with pytest.raises(ValidationError, match="open.spotify.com"):
+            CheckpointMediaCreate(kind=MediaKind.spotify, content_url=url)
+
+    def test_spotify_requires_content_url(self) -> None:
+        with pytest.raises(ValidationError, match="content_url"):
+            CheckpointMediaCreate(kind=MediaKind.spotify)
+
+    def test_spotify_rejects_content_text(self) -> None:
+        with pytest.raises(ValidationError, match="content_text"):
+            CheckpointMediaCreate(
+                kind=MediaKind.spotify,
+                content_url="https://open.spotify.com/track/abc",
+                content_text="not allowed",
+            )
+
+    def test_link_accepts_https_url(self) -> None:
+        media = CheckpointMediaCreate(kind=MediaKind.link, content_url="https://example.com")
+        assert media.content_url == "https://example.com"
+
+    def test_link_accepts_http_url(self) -> None:
+        media = CheckpointMediaCreate(kind=MediaKind.link, content_url="http://example.com")
+        assert media.content_url == "http://example.com"
+
+    def test_link_rejects_javascript_scheme(self) -> None:
+        with pytest.raises(ValidationError, match="http"):
+            CheckpointMediaCreate(kind=MediaKind.link, content_url="javascript:alert(1)")
+
+    def test_link_requires_content_url(self) -> None:
+        with pytest.raises(ValidationError, match="content_url"):
+            CheckpointMediaCreate(kind=MediaKind.link)
+
+    def test_fun_fact_requires_caption(self) -> None:
+        with pytest.raises(ValidationError, match="caption"):
+            CheckpointMediaCreate(kind=MediaKind.fun_fact)
+
+    def test_fun_fact_accepts_caption(self) -> None:
+        media = CheckpointMediaCreate(kind=MediaKind.fun_fact, caption="Did you know...")
+        assert media.caption == "Did you know..."
+
+    def test_photo_rejects_content_url(self) -> None:
+        with pytest.raises(ValidationError, match="content_url"):
+            CheckpointMediaCreate(kind=MediaKind.photo, content_url="https://example.com")
+
+    def test_photo_rejects_content_text(self) -> None:
+        with pytest.raises(ValidationError, match="content_text"):
+            CheckpointMediaCreate(kind=MediaKind.photo, content_text="payload")
+
+    def test_photo_and_fun_fact_reject_title(self) -> None:
+        with pytest.raises(ValidationError, match="title"):
+            CheckpointMediaCreate(kind=MediaKind.photo, title="Not allowed")
+
+
+class TestValidateUpdateAgainstKind:
+    def test_allows_matching_field(self) -> None:
+        validate_update_against_kind(
+            CheckpointMediaUpdate(content_text="new payload"), kind=MediaKind.qr
+        )  # no raise
+
+    def test_allows_partial_update_touching_nothing_kind_specific(self) -> None:
+        validate_update_against_kind(CheckpointMediaUpdate(caption="new"), kind=MediaKind.qr)
+
+    def test_rejects_mismatched_field(self) -> None:
+        with pytest.raises(ValueError, match="content_url"):
+            validate_update_against_kind(
+                CheckpointMediaUpdate(content_url="https://example.com"), kind=MediaKind.qr
+            )

--- a/web-rally/openapi.json
+++ b/web-rally/openapi.json
@@ -8058,6 +8058,39 @@
             "title": "Order",
             "default": 0
           },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "content_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Url"
+          },
+          "content_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Text"
+          },
           "image": {
             "anyOf": [
               {
@@ -8100,6 +8133,39 @@
               }
             ],
             "title": "Order"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "content_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Url"
+          },
+          "content_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Text"
           },
           "image": {
             "anyOf": [
@@ -8745,6 +8811,39 @@
             "type": "integer",
             "title": "Order",
             "default": 0
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "content_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Url"
+          },
+          "content_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Text"
           },
           "id": {
             "type": "integer",
@@ -10193,7 +10292,10 @@
         "type": "string",
         "enum": [
           "photo",
-          "fun_fact"
+          "fun_fact",
+          "qr",
+          "spotify",
+          "link"
         ],
         "title": "MediaKind"
       },

--- a/web-rally/src/components/shared/checkpoint/CheckpointDiscovery.tsx
+++ b/web-rally/src/components/shared/checkpoint/CheckpointDiscovery.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Lightbulb, Compass } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useCheckpointMedia } from "@/hooks/useCheckpointMedia";
+import CheckpointMediaAttachment from "./CheckpointMediaAttachment";
 
 type CheckpointDiscoveryProps = Readonly<{
   checkpointId: number;
@@ -30,10 +31,11 @@ export default function CheckpointDiscovery({
   heading,
   className,
 }: CheckpointDiscoveryProps) {
-  const { photos, funFacts } = useCheckpointMedia(checkpointId, enabled);
+  const { photos, funFacts, attachments } = useCheckpointMedia(checkpointId, enabled);
   const [lightbox, setLightbox] = useState<string | null>(null);
 
-  const hasContent = !!description || photos.length > 0 || funFacts.length > 0;
+  const hasContent =
+    !!description || photos.length > 0 || funFacts.length > 0 || attachments.length > 0;
   if (!hasContent) return null;
 
   const thumb = compact ? "h-20 w-28" : "h-28 w-40 sm:h-32 sm:w-48";
@@ -95,6 +97,14 @@ export default function CheckpointDiscovery({
             </li>
           ))}
         </ul>
+      )}
+
+      {attachments.length > 0 && (
+        <div className="space-y-2.5">
+          {attachments.map((item) => (
+            <CheckpointMediaAttachment key={item.id} item={item} compact={compact} />
+          ))}
+        </div>
       )}
 
       {lightbox && (

--- a/web-rally/src/components/shared/checkpoint/CheckpointMediaAttachment.test.tsx
+++ b/web-rally/src/components/shared/checkpoint/CheckpointMediaAttachment.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import CheckpointMediaAttachment from "./CheckpointMediaAttachment";
+import type { CheckpointMediaResponse } from "@/client";
+
+const base: CheckpointMediaResponse = {
+  id: 1,
+  checkpoint_id: 1,
+  kind: "qr",
+  caption: null,
+  order: 0,
+  title: null,
+  content_url: null,
+  content_text: null,
+  image_url: null,
+};
+
+describe("CheckpointMediaAttachment", () => {
+  it("renders a QR code for a qr item", () => {
+    render(
+      <CheckpointMediaAttachment item={{ ...base, kind: "qr", content_text: "riddle-payload" }} />,
+    );
+    expect(document.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("shows the caption alongside the qr code", () => {
+    render(
+      <CheckpointMediaAttachment
+        item={{ ...base, kind: "qr", content_text: "riddle", caption: "Aponta aqui" }}
+      />,
+    );
+    expect(screen.getByText("Aponta aqui")).toBeInTheDocument();
+  });
+
+  it("renders a Spotify iframe for a valid open.spotify.com URL", () => {
+    render(
+      <CheckpointMediaAttachment
+        item={{
+          ...base,
+          kind: "spotify",
+          content_url: "https://open.spotify.com/track/abc123",
+          title: "Ouve isto",
+        }}
+      />,
+    );
+    const iframe = document.querySelector("iframe");
+    expect(iframe).toBeInTheDocument();
+    expect(iframe).toHaveAttribute("src", "https://open.spotify.com/embed/track/abc123");
+    expect(iframe).toHaveAttribute("sandbox");
+    expect(screen.getByText("Ouve isto")).toBeInTheDocument();
+  });
+
+  it("renders nothing for a spotify item whose URL doesn't parse into an embed", () => {
+    const { container } = render(
+      <CheckpointMediaAttachment
+        item={{ ...base, kind: "spotify", content_url: "https://open.spotify.com/artist/abc" }}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders an external link for a link item", () => {
+    render(
+      <CheckpointMediaAttachment
+        item={{ ...base, kind: "link", content_url: "https://example.com", title: "Site oficial" }}
+      />,
+    );
+    const link = screen.getByRole("link", { name: /Site oficial/ });
+    expect(link).toHaveAttribute("href", "https://example.com");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("falls back to the raw URL as link text when no title is set", () => {
+    render(
+      <CheckpointMediaAttachment
+        item={{ ...base, kind: "link", content_url: "https://example.com" }}
+      />,
+    );
+    expect(screen.getByText("https://example.com")).toBeInTheDocument();
+  });
+
+  it("renders nothing for photo/fun_fact — those stay in CheckpointDiscovery", () => {
+    const { container } = render(<CheckpointMediaAttachment item={{ ...base, kind: "photo" }} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/web-rally/src/components/shared/checkpoint/CheckpointMediaAttachment.tsx
+++ b/web-rally/src/components/shared/checkpoint/CheckpointMediaAttachment.tsx
@@ -1,0 +1,66 @@
+import { QRCodeSVG } from "qrcode.react";
+import { ExternalLink } from "lucide-react";
+import type { CheckpointMediaResponse } from "@/client";
+import { toSpotifyEmbedUrl } from "@/utils/spotifyEmbed";
+
+type Props = Readonly<{
+  item: CheckpointMediaResponse;
+  compact?: boolean;
+}>;
+
+/**
+ * Renders one `qr`/`spotify`/`link` checkpoint-media item for a team.
+ * Photo and fun_fact stay inline in `CheckpointDiscovery.tsx` (their
+ * rendering is entangled with the shared lightbox state); this dispatcher
+ * only covers the three rich-media kinds so it stays a pure, stateless leaf.
+ */
+export default function CheckpointMediaAttachment({ item, compact = false }: Props) {
+  if (item.kind === "qr" && item.content_text) {
+    return (
+      <div className="flex items-center gap-3 rounded-xl border border-border bg-card/60 p-3">
+        <div className="shrink-0 rounded-lg bg-white p-2">
+          <QRCodeSVG value={item.content_text} size={compact ? 96 : 140} level="M" />
+        </div>
+        {item.caption && <p className="text-sm text-foreground/90">{item.caption}</p>}
+      </div>
+    );
+  }
+
+  if (item.kind === "spotify" && item.content_url) {
+    const embedUrl = toSpotifyEmbedUrl(item.content_url);
+    if (!embedUrl) return null;
+    return (
+      <div className="space-y-1.5">
+        {item.title && <p className="text-sm font-medium text-foreground/90">{item.title}</p>}
+        <iframe
+          title={item.title ?? "Spotify"}
+          src={embedUrl}
+          width="100%"
+          height={compact ? 80 : 152}
+          loading="lazy"
+          allow="encrypted-media"
+          // Admin-supplied URL, restricted to open.spotify.com server-side —
+          // sandboxed anyway since this page also carries team auth state.
+          sandbox="allow-scripts allow-same-origin allow-popups"
+          className="rounded-xl border border-border"
+        />
+      </div>
+    );
+  }
+
+  if (item.kind === "link" && item.content_url) {
+    return (
+      <a
+        href={item.content_url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center gap-2 rounded-xl border border-border bg-card/60 px-3 py-2.5 text-sm text-foreground/90 transition hover:border-primary"
+      >
+        <ExternalLink className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <span className="truncate">{item.title || item.content_url}</span>
+      </a>
+    );
+  }
+
+  return null;
+}

--- a/web-rally/src/hooks/useCheckpointMedia.ts
+++ b/web-rally/src/hooks/useCheckpointMedia.ts
@@ -4,6 +4,9 @@ import { listCheckpointMedia, type CheckpointMediaResponse } from "@/client";
 export interface CheckpointMediaGrouped {
   photos: CheckpointMediaResponse[];
   funFacts: CheckpointMediaResponse[];
+  /** Every `qr`/`spotify`/`link` item, sorted by order — dispatched one by
+   * one to `CheckpointMediaAttachment`. */
+  attachments: CheckpointMediaResponse[];
   isLoading: boolean;
 }
 
@@ -26,6 +29,9 @@ export function useCheckpointMedia(checkpointId: number, enabled = true): Checkp
 
   const photos = data.filter((m) => m.kind === "photo" && m.image_url).sort(byOrder);
   const funFacts = data.filter((m) => m.kind === "fun_fact" && m.caption).sort(byOrder);
+  const attachments = data
+    .filter((m) => m.kind === "qr" || m.kind === "spotify" || m.kind === "link")
+    .sort(byOrder);
 
-  return { photos, funFacts, isLoading };
+  return { photos, funFacts, attachments, isLoading };
 }

--- a/web-rally/src/pages/admin/components/checkpoints/CheckpointMediaManager.tsx
+++ b/web-rally/src/pages/admin/components/checkpoints/CheckpointMediaManager.tsx
@@ -1,29 +1,34 @@
-import { useRef, useState, type ChangeEvent } from "react";
+import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ImagePlus, Lightbulb, Trash2, Loader2, Image as ImageIcon } from "lucide-react";
+import { Loader2, Plus } from "lucide-react";
 import {
   listCheckpointMedia,
   createCheckpointMedia,
   deleteCheckpointMedia,
+  reorderCheckpointMedia,
   type CheckpointMediaResponse,
+  type MediaKind,
 } from "@/client";
 import { BloodyButton } from "@/components/themes/bloody";
-import { Input } from "@/components/ui/input";
 import { useAppToast } from "@/hooks/use-toast";
 import { getErrorMessage } from "@/utils/errorHandling";
+import { MEDIA_KIND_CONFIG, MEDIA_KIND_ORDER } from "./media/mediaKindConfig";
+import { EMPTY_DRAFT, type MediaDraft } from "./media/mediaDraft";
+import CheckpointMediaRow from "./media/CheckpointMediaRow";
 
 type CheckpointMediaManagerProps = Readonly<{
   checkpointId: number;
 }>;
 
-const fieldClassName = "bg-muted border-border";
-
+/** Everything a post can carry beyond its riddle text — photos, curiosities,
+ * QR codes, Spotify links, plain links — one ordered mixed list, added
+ * through a kind-dispatched form (see `media/mediaKindConfig.ts`) and
+ * reordered with up/down arrows against the existing reorder endpoint. */
 export default function CheckpointMediaManager({ checkpointId }: CheckpointMediaManagerProps) {
   const toast = useAppToast();
   const qc = useQueryClient();
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const [photoCaption, setPhotoCaption] = useState("");
-  const [funFact, setFunFact] = useState("");
+  const [kind, setKind] = useState<MediaKind>("photo");
+  const [draft, setDraft] = useState<MediaDraft>(EMPTY_DRAFT);
 
   const queryKey = ["checkpoint-media", checkpointId];
 
@@ -37,40 +42,25 @@ export default function CheckpointMediaManager({ checkpointId }: CheckpointMedia
 
   const invalidate = () => void qc.invalidateQueries({ queryKey });
 
-  const uploadPhoto = useMutation({
-    mutationFn: (image: Blob) =>
+  const addMedia = useMutation({
+    mutationFn: () =>
       createCheckpointMedia({
         path: { checkpoint_id: checkpointId },
         body: {
-          kind: "photo",
-          caption: photoCaption || null,
-          image,
+          kind,
+          caption: draft.caption || null,
+          title: draft.title || null,
+          content_url: draft.contentUrl || null,
+          content_text: draft.contentText || null,
+          image: draft.image,
         },
       }),
     onSuccess: () => {
       invalidate();
-      setPhotoCaption("");
-      if (fileInputRef.current) fileInputRef.current.value = "";
-      toast.success("Foto do sítio adicionada!");
+      setDraft(EMPTY_DRAFT);
+      toast.success("Adicionado!");
     },
-    onError: (error) => toast.error(getErrorMessage(error, "Erro ao enviar foto")),
-  });
-
-  const addFunFact = useMutation({
-    mutationFn: (caption: string) =>
-      createCheckpointMedia({
-        path: { checkpoint_id: checkpointId },
-        body: {
-          kind: "fun_fact",
-          caption,
-        },
-      }),
-    onSuccess: () => {
-      invalidate();
-      setFunFact("");
-      toast.success("Curiosidade adicionada!");
-    },
-    onError: (error) => toast.error(getErrorMessage(error, "Erro ao adicionar curiosidade")),
+    onError: (error) => toast.error(getErrorMessage(error, "Erro ao adicionar")),
   });
 
   const deleteMedia = useMutation({
@@ -82,162 +72,99 @@ export default function CheckpointMediaManager({ checkpointId }: CheckpointMedia
     onError: (error) => toast.error(getErrorMessage(error, "Erro ao remover")),
   });
 
-  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) uploadPhoto.mutate(file);
+  const reorder = useMutation({
+    mutationFn: (orderedIds: number[]) =>
+      reorderCheckpointMedia({ path: { checkpoint_id: checkpointId }, body: orderedIds }),
+    onSuccess: (res) => {
+      if (res.data) qc.setQueryData(queryKey, res.data);
+    },
+    onError: () => {
+      invalidate();
+      toast.error("Erro ao reordenar");
+    },
+  });
+
+  const moveItem = (index: number, direction: -1 | 1) => {
+    const target = index + direction;
+    if (target < 0 || target >= media.length) return;
+    const next = [...media];
+    [next[index], next[target]] = [next[target]!, next[index]!];
+    reorder.mutate(next.map((m) => m.id));
   };
 
-  const handleAddFunFact = () => {
-    const trimmed = funFact.trim();
-    if (trimmed) addFunFact.mutate(trimmed);
-  };
-
-  const photos = media.filter((m) => m.kind === "photo");
-  const funFacts = media.filter((m) => m.kind === "fun_fact");
-
-  let photosContent;
-  if (isLoading) {
-    photosContent = (
-      <div className="flex items-center gap-2 text-xs text-muted-foreground">
-        <Loader2 className="h-4 w-4 animate-spin" /> A carregar…
-      </div>
-    );
-  } else if (photos.length > 0) {
-    photosContent = (
-      <div className="flex flex-wrap gap-3">
-        {photos.map((m) => (
-          <div key={m.id} className="group relative">
-            <img
-              src={m.image_url ?? ""}
-              alt={m.caption ?? "Foto do sítio"}
-              className="h-24 w-24 rounded-lg object-cover ring-1 ring-border"
-            />
-            <button
-              type="button"
-              onClick={() => deleteMedia.mutate(m.id)}
-              disabled={deleteMedia.isPending}
-              className="absolute -right-2 -top-2 grid h-6 w-6 place-items-center rounded-full bg-destructive text-destructive-foreground opacity-0 shadow transition group-hover:opacity-100"
-              aria-label="Remover foto"
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-            </button>
-            {m.caption && (
-              <p className="mt-1 line-clamp-1 w-24 text-[10px] text-muted-foreground">
-                {m.caption}
-              </p>
-            )}
-          </div>
-        ))}
-      </div>
-    );
-  } else {
-    photosContent = (
-      <p className="text-xs text-muted-foreground">
-        Ainda sem fotos. Envie a primeira para a equipa adivinhar o sítio.
-      </p>
-    );
-  }
+  const canSubmit = !addMedia.isPending;
+  const { FieldsComponent } = MEDIA_KIND_CONFIG[kind];
 
   return (
-    <div className="space-y-5 border-t border-border pt-4">
-      {/* Photos */}
-      <section className="space-y-3">
-        <div className="flex items-center gap-2 text-sm font-semibold">
-          <ImageIcon className="h-4 w-4 text-primary" />
-          Fotos do sítio
-          <span className="text-xs font-normal text-muted-foreground">({photos.length})</span>
+    <div className="space-y-4 border-t border-border pt-4">
+      <div className="flex items-center gap-2 text-sm font-semibold">
+        Media do posto
+        <span className="text-xs font-normal text-muted-foreground">({media.length})</span>
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> A carregar…
         </div>
-
-        {photosContent}
-
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-          <Input
-            value={photoCaption}
-            onChange={(e) => setPhotoCaption(e.target.value)}
-            placeholder="Legenda (opcional)"
-            className={`${fieldClassName} sm:max-w-xs`}
-          />
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept="image/*"
-            onChange={handleFileChange}
-            className="hidden"
-          />
-          <BloodyButton
-            type="button"
-            variant="neutral"
-            onClick={() => fileInputRef.current?.click()}
-            disabled={uploadPhoto.isPending}
-          >
-            {uploadPhoto.isPending ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <ImagePlus className="h-4 w-4" />
-            )}
-            <span className="ml-1.5">Enviar foto</span>
-          </BloodyButton>
-        </div>
-      </section>
-
-      {/* Fun facts */}
-      <section className="space-y-3">
-        <div className="flex items-center gap-2 text-sm font-semibold">
-          <Lightbulb className="h-4 w-4 text-amber-500" />
-          Curiosidades
-          <span className="text-xs font-normal text-muted-foreground">({funFacts.length})</span>
-        </div>
-
-        {funFacts.length > 0 && (
+      ) : (
+        media.length > 0 && (
           <ul className="space-y-2">
-            {funFacts.map((m) => (
-              <li
-                key={m.id}
-                className="flex items-start justify-between gap-3 rounded-lg bg-muted/50 px-3 py-2 text-sm"
-              >
-                <span className="flex-1">{m.caption}</span>
-                <button
-                  type="button"
-                  onClick={() => deleteMedia.mutate(m.id)}
-                  disabled={deleteMedia.isPending}
-                  className="shrink-0 text-muted-foreground transition hover:text-destructive"
-                  aria-label="Remover curiosidade"
-                >
-                  <Trash2 className="h-4 w-4" />
-                </button>
-              </li>
+            {media.map((item, index) => (
+              <CheckpointMediaRow
+                key={item.id}
+                item={item}
+                isFirst={index === 0}
+                isLast={index === media.length - 1}
+                onMove={(direction) => moveItem(index, direction)}
+                onDelete={() => deleteMedia.mutate(item.id)}
+                deleteDisabled={deleteMedia.isPending}
+              />
             ))}
           </ul>
-        )}
+        )
+      )}
 
-        <div className="flex flex-col gap-2 sm:flex-row">
-          <Input
-            value={funFact}
-            onChange={(e) => setFunFact(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                handleAddFunFact();
-              }
-            }}
-            placeholder="Ex: Este edifício foi construído em 1890…"
-            className={`${fieldClassName} flex-1`}
-          />
-          <BloodyButton
-            type="button"
-            variant="neutral"
-            onClick={handleAddFunFact}
-            disabled={addFunFact.isPending || !funFact.trim()}
-          >
-            {addFunFact.isPending ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <Lightbulb className="h-4 w-4" />
-            )}
-            <span className="ml-1.5">Adicionar</span>
-          </BloodyButton>
+      <div className="space-y-2 rounded-lg border border-dashed border-border p-3">
+        <div className="flex flex-wrap gap-1.5">
+          {MEDIA_KIND_ORDER.map((k) => {
+            const { label, icon: Icon } = MEDIA_KIND_CONFIG[k];
+            return (
+              <button
+                key={k}
+                type="button"
+                onClick={() => {
+                  setKind(k);
+                  setDraft(EMPTY_DRAFT);
+                }}
+                className={`flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium transition ${
+                  kind === k
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-muted text-muted-foreground hover:bg-accent"
+                }`}
+              >
+                <Icon className="h-3.5 w-3.5" />
+                {label}
+              </button>
+            );
+          })}
         </div>
-      </section>
+
+        <FieldsComponent draft={draft} onChange={(patch) => setDraft({ ...draft, ...patch })} />
+
+        <BloodyButton
+          type="button"
+          variant="neutral"
+          onClick={() => addMedia.mutate()}
+          disabled={!canSubmit}
+        >
+          {addMedia.isPending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Plus className="h-4 w-4" />
+          )}
+          <span className="ml-1.5">Adicionar</span>
+        </BloodyButton>
+      </div>
     </div>
   );
 }

--- a/web-rally/src/pages/admin/components/checkpoints/media/CheckpointMediaRow.tsx
+++ b/web-rally/src/pages/admin/components/checkpoints/media/CheckpointMediaRow.tsx
@@ -1,0 +1,91 @@
+import { ArrowUp, ArrowDown, Trash2 } from "lucide-react";
+import type { CheckpointMediaResponse } from "@/client";
+import { MEDIA_KIND_CONFIG } from "./mediaKindConfig";
+
+type Props = Readonly<{
+  item: CheckpointMediaResponse;
+  isFirst: boolean;
+  isLast: boolean;
+  onMove: (direction: -1 | 1) => void;
+  onDelete: () => void;
+  deleteDisabled?: boolean;
+}>;
+
+function summaryFor(item: CheckpointMediaResponse): string {
+  switch (item.kind) {
+    case "photo":
+      return item.caption || "Foto";
+    case "fun_fact":
+      return item.caption ?? "";
+    case "qr":
+      return item.content_text ?? "";
+    case "spotify":
+      return item.title || item.content_url || "Spotify";
+    case "link":
+      return item.title || item.content_url || "Link";
+    default:
+      return "";
+  }
+}
+
+/** One row in the checkpoint media list — kind icon, a kind-specific
+ * one-line summary, and up/down reorder buttons instead of drag-and-drop
+ * (no such library exists in this codebase yet, and the list is always
+ * short enough that arrows are simpler than adding one). */
+export default function CheckpointMediaRow({
+  item,
+  isFirst,
+  isLast,
+  onMove,
+  onDelete,
+  deleteDisabled,
+}: Props) {
+  const { label, icon: Icon } = MEDIA_KIND_CONFIG[item.kind];
+
+  return (
+    <li className="flex items-center gap-3 rounded-lg bg-muted/50 px-3 py-2 text-sm">
+      <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+      {item.kind === "photo" && item.image_url && (
+        <img
+          src={item.image_url}
+          alt={item.caption ?? "Foto"}
+          className="h-8 w-8 shrink-0 rounded object-cover ring-1 ring-border"
+        />
+      )}
+      <div className="min-w-0 flex-1">
+        <p className="text-xs font-medium text-muted-foreground">{label}</p>
+        <p className="truncate">{summaryFor(item)}</p>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-0.5">
+        <button
+          type="button"
+          disabled={isFirst}
+          onClick={() => onMove(-1)}
+          aria-label="Mover para cima"
+          className="rounded p-1 text-muted-foreground transition hover:bg-accent disabled:opacity-30"
+        >
+          <ArrowUp className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          disabled={isLast}
+          onClick={() => onMove(1)}
+          aria-label="Mover para baixo"
+          className="rounded p-1 text-muted-foreground transition hover:bg-accent disabled:opacity-30"
+        >
+          <ArrowDown className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          onClick={onDelete}
+          disabled={deleteDisabled}
+          aria-label={`Remover ${label.toLowerCase()}`}
+          className="rounded p-1 text-muted-foreground transition hover:text-destructive"
+        >
+          <Trash2 className="h-4 w-4" />
+        </button>
+      </div>
+    </li>
+  );
+}

--- a/web-rally/src/pages/admin/components/checkpoints/media/FunFactMediaFields.tsx
+++ b/web-rally/src/pages/admin/components/checkpoints/media/FunFactMediaFields.tsx
@@ -1,0 +1,18 @@
+import { Input } from "@/components/ui/input";
+import type { MediaDraft, MediaDraftPatch } from "./mediaDraft";
+
+type Props = Readonly<{
+  draft: MediaDraft;
+  onChange: (patch: MediaDraftPatch) => void;
+}>;
+
+export default function FunFactMediaFields({ draft, onChange }: Props) {
+  return (
+    <Input
+      value={draft.caption}
+      onChange={(e) => onChange({ caption: e.target.value })}
+      placeholder="Ex: Este edifício foi construído em 1890…"
+      className="border-border bg-muted"
+    />
+  );
+}

--- a/web-rally/src/pages/admin/components/checkpoints/media/LinkMediaFields.tsx
+++ b/web-rally/src/pages/admin/components/checkpoints/media/LinkMediaFields.tsx
@@ -1,0 +1,26 @@
+import { Input } from "@/components/ui/input";
+import type { MediaDraft, MediaDraftPatch } from "./mediaDraft";
+
+type Props = Readonly<{
+  draft: MediaDraft;
+  onChange: (patch: MediaDraftPatch) => void;
+}>;
+
+export default function LinkMediaFields({ draft, onChange }: Props) {
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+      <Input
+        value={draft.contentUrl}
+        onChange={(e) => onChange({ contentUrl: e.target.value })}
+        placeholder="https://…"
+        className="border-border bg-muted sm:max-w-sm"
+      />
+      <Input
+        value={draft.title}
+        onChange={(e) => onChange({ title: e.target.value })}
+        placeholder="Título (opcional)"
+        className="border-border bg-muted sm:max-w-xs"
+      />
+    </div>
+  );
+}

--- a/web-rally/src/pages/admin/components/checkpoints/media/PhotoMediaFields.tsx
+++ b/web-rally/src/pages/admin/components/checkpoints/media/PhotoMediaFields.tsx
@@ -1,0 +1,26 @@
+import { Input } from "@/components/ui/input";
+import type { MediaDraft, MediaDraftPatch } from "./mediaDraft";
+
+type Props = Readonly<{
+  draft: MediaDraft;
+  onChange: (patch: MediaDraftPatch) => void;
+}>;
+
+export default function PhotoMediaFields({ draft, onChange }: Props) {
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+      <Input
+        value={draft.caption}
+        onChange={(e) => onChange({ caption: e.target.value })}
+        placeholder="Legenda (opcional)"
+        className="border-border bg-muted sm:max-w-xs"
+      />
+      <input
+        type="file"
+        accept="image/*"
+        onChange={(e) => onChange({ image: e.target.files?.[0] ?? null })}
+        className="text-sm text-muted-foreground"
+      />
+    </div>
+  );
+}

--- a/web-rally/src/pages/admin/components/checkpoints/media/QrMediaFields.tsx
+++ b/web-rally/src/pages/admin/components/checkpoints/media/QrMediaFields.tsx
@@ -1,0 +1,29 @@
+import { QRCodeSVG } from "qrcode.react";
+import { Input } from "@/components/ui/input";
+import type { MediaDraft, MediaDraftPatch } from "./mediaDraft";
+
+type Props = Readonly<{
+  draft: MediaDraft;
+  onChange: (patch: MediaDraftPatch) => void;
+}>;
+
+/** Live QR preview as the admin types, so they see exactly what the team
+ * will scan before saving — reuses the white-card convention from
+ * `QRCodeDisplay.tsx` so the code stays scannable in dark themes. */
+export default function QrMediaFields({ draft, onChange }: Props) {
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-start">
+      <Input
+        value={draft.contentText}
+        onChange={(e) => onChange({ contentText: e.target.value })}
+        placeholder="URL ou texto a codificar no QR"
+        className="border-border bg-muted sm:max-w-sm"
+      />
+      {draft.contentText.trim() && (
+        <div className="w-fit shrink-0 rounded-lg bg-white p-2">
+          <QRCodeSVG value={draft.contentText} size={64} level="M" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web-rally/src/pages/admin/components/checkpoints/media/SpotifyMediaFields.tsx
+++ b/web-rally/src/pages/admin/components/checkpoints/media/SpotifyMediaFields.tsx
@@ -1,0 +1,38 @@
+import { Input } from "@/components/ui/input";
+import type { MediaDraft, MediaDraftPatch } from "./mediaDraft";
+
+// Mirrors the backend's SPOTIFY_URL_PATTERN — fails fast client-side before
+// the round-trip to the API for an obviously wrong domain.
+const SPOTIFY_URL_PATTERN = /^https:\/\/open\.spotify\.com\//;
+
+type Props = Readonly<{
+  draft: MediaDraft;
+  onChange: (patch: MediaDraftPatch) => void;
+}>;
+
+export default function SpotifyMediaFields({ draft, onChange }: Props) {
+  const urlLooksInvalid =
+    draft.contentUrl.trim().length > 0 && !SPOTIFY_URL_PATTERN.test(draft.contentUrl);
+
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+      <div className="sm:max-w-sm">
+        <Input
+          value={draft.contentUrl}
+          onChange={(e) => onChange({ contentUrl: e.target.value })}
+          placeholder="https://open.spotify.com/track/…"
+          className="border-border bg-muted"
+        />
+        {urlLooksInvalid && (
+          <p className="mt-1 text-xs text-destructive">Tem de ser um link open.spotify.com</p>
+        )}
+      </div>
+      <Input
+        value={draft.title}
+        onChange={(e) => onChange({ title: e.target.value })}
+        placeholder="Título (opcional)"
+        className="border-border bg-muted sm:max-w-xs"
+      />
+    </div>
+  );
+}

--- a/web-rally/src/pages/admin/components/checkpoints/media/mediaDraft.ts
+++ b/web-rally/src/pages/admin/components/checkpoints/media/mediaDraft.ts
@@ -1,0 +1,20 @@
+/** Shared draft shape for the "add media" form — one flat object regardless
+ * of which kind is selected, so switching kinds in the selector doesn't lose
+ * whatever the admin already typed into an unrelated field. */
+export interface MediaDraft {
+  caption: string;
+  title: string;
+  contentUrl: string;
+  contentText: string;
+  image: File | null;
+}
+
+export const EMPTY_DRAFT: MediaDraft = {
+  caption: "",
+  title: "",
+  contentUrl: "",
+  contentText: "",
+  image: null,
+};
+
+export type MediaDraftPatch = Partial<MediaDraft>;

--- a/web-rally/src/pages/admin/components/checkpoints/media/mediaKindConfig.ts
+++ b/web-rally/src/pages/admin/components/checkpoints/media/mediaKindConfig.ts
@@ -1,0 +1,29 @@
+import { Image as ImageIcon, Lightbulb, QrCode, Music, Link as LinkIcon } from "lucide-react";
+import type { MediaKind } from "@/client";
+import type { MediaDraft, MediaDraftPatch } from "./mediaDraft";
+import PhotoMediaFields from "./PhotoMediaFields";
+import FunFactMediaFields from "./FunFactMediaFields";
+import QrMediaFields from "./QrMediaFields";
+import SpotifyMediaFields from "./SpotifyMediaFields";
+import LinkMediaFields from "./LinkMediaFields";
+
+type FieldsComponent = (props: {
+  draft: MediaDraft;
+  onChange: (patch: MediaDraftPatch) => void;
+}) => React.JSX.Element;
+
+/** Single place to register a new media kind's admin label, icon, and
+ * add-form fields — the kind selector, the row summary, and the add form
+ * all read from this instead of switching on `kind` at every call site. */
+export const MEDIA_KIND_CONFIG: Record<
+  MediaKind,
+  { label: string; icon: typeof ImageIcon; FieldsComponent: FieldsComponent }
+> = {
+  photo: { label: "Foto", icon: ImageIcon, FieldsComponent: PhotoMediaFields },
+  fun_fact: { label: "Curiosidade", icon: Lightbulb, FieldsComponent: FunFactMediaFields },
+  qr: { label: "QR code", icon: QrCode, FieldsComponent: QrMediaFields },
+  spotify: { label: "Spotify", icon: Music, FieldsComponent: SpotifyMediaFields },
+  link: { label: "Link", icon: LinkIcon, FieldsComponent: LinkMediaFields },
+};
+
+export const MEDIA_KIND_ORDER: MediaKind[] = ["photo", "fun_fact", "qr", "spotify", "link"];

--- a/web-rally/src/utils/errorHandling.ts
+++ b/web-rally/src/utils/errorHandling.ts
@@ -6,6 +6,7 @@
  * Extracts a user-friendly error message from various error types
  *
  * Handles different error formats:
+ * - Our generated API client's thrown errors: raw `{ detail }` at the top level
  * - API errors with body.detail
  * - Axios errors with response.data.detail
  * - Standard Error objects with message
@@ -30,10 +31,17 @@ export function getErrorMessage(error: unknown, fallback: string): string {
   }
 
   const candidate = error as {
+    detail?: string;
     body?: { detail?: string };
     response?: { data?: { detail?: string } };
     message?: string;
   };
+
+  // Try top-level detail — our generated client (throwOnError) throws the
+  // parsed JSON error body as-is, e.g. `{ detail: "..." }`.
+  if (typeof candidate.detail === "string") {
+    return candidate.detail;
+  }
 
   // Try body.detail (some API error formats)
   if (typeof candidate.body?.detail === "string") {

--- a/web-rally/src/utils/spotifyEmbed.test.ts
+++ b/web-rally/src/utils/spotifyEmbed.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { toSpotifyEmbedUrl } from "./spotifyEmbed";
+
+describe("toSpotifyEmbedUrl", () => {
+  it("rewrites a track URL to the embed path", () => {
+    expect(toSpotifyEmbedUrl("https://open.spotify.com/track/abc123")).toBe(
+      "https://open.spotify.com/embed/track/abc123",
+    );
+  });
+
+  it("rewrites a playlist URL to the embed path", () => {
+    expect(toSpotifyEmbedUrl("https://open.spotify.com/playlist/xyz789")).toBe(
+      "https://open.spotify.com/embed/playlist/xyz789",
+    );
+  });
+
+  it("strips query params and trailing segments", () => {
+    expect(toSpotifyEmbedUrl("https://open.spotify.com/track/abc123?si=xyz")).toBe(
+      "https://open.spotify.com/embed/track/abc123",
+    );
+  });
+
+  it("returns null for a non-spotify URL", () => {
+    expect(toSpotifyEmbedUrl("https://evil.com/track/abc123")).toBeNull();
+  });
+
+  it("returns null for an unrecognised content type", () => {
+    expect(toSpotifyEmbedUrl("https://open.spotify.com/artist/abc123")).toBeNull();
+  });
+});

--- a/web-rally/src/utils/spotifyEmbed.ts
+++ b/web-rally/src/utils/spotifyEmbed.ts
@@ -1,0 +1,12 @@
+// Rewrites an open.spotify.com content link into Spotify's documented embed
+// URL (open.spotify.com/embed/<type>/<id>) — no oEmbed network round-trip
+// needed, Spotify serves the iframe player directly at that path.
+const SPOTIFY_CONTENT_PATTERN =
+  /^https:\/\/open\.spotify\.com\/(track|album|playlist|episode|show)\/([A-Za-z0-9]+)/;
+
+export function toSpotifyEmbedUrl(url: string): string | null {
+  const match = SPOTIFY_CONTENT_PATTERN.exec(url);
+  if (!match) return null;
+  const [, type, id] = match;
+  return `https://open.spotify.com/embed/${type}/${id}`;
+}

--- a/web-rally/tests/e2e/admin-checkpoints.spec.ts
+++ b/web-rally/tests/e2e/admin-checkpoints.spec.ts
@@ -179,7 +179,7 @@ test.describe('Admin checkpoints', () => {
     await page.getByLabel('Fotos e curiosidades do sítio').click();
     const fileInput = page.locator('input[type="file"]');
     await fileInput.setInputFiles({ name: 'photo.png', mimeType: 'image/png', buffer: Buffer.from('fake') });
-    await page.getByRole('button', { name: 'Adicionar' }).click();
+    await page.getByRole('button', { name: 'Adicionar', exact: true }).click();
 
     await expect(page.getByText(/R2 storage is not configured/)).toBeVisible();
   });

--- a/web-rally/tests/e2e/admin-checkpoints.spec.ts
+++ b/web-rally/tests/e2e/admin-checkpoints.spec.ts
@@ -179,6 +179,7 @@ test.describe('Admin checkpoints', () => {
     await page.getByLabel('Fotos e curiosidades do sítio').click();
     const fileInput = page.locator('input[type="file"]');
     await fileInput.setInputFiles({ name: 'photo.png', mimeType: 'image/png', buffer: Buffer.from('fake') });
+    await page.getByRole('button', { name: 'Adicionar' }).click();
 
     await expect(page.getByText(/R2 storage is not configured/)).toBeVisible();
   });

--- a/web-rally/tests/unit/pages/admin/components/CheckpointMediaManager.test.tsx
+++ b/web-rally/tests/unit/pages/admin/components/CheckpointMediaManager.test.tsx
@@ -1,32 +1,35 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import CheckpointMediaManager from '@/pages/admin/components/checkpoints/CheckpointMediaManager';
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import CheckpointMediaManager from "@/pages/admin/components/checkpoints/CheckpointMediaManager";
 
 const {
   mockListCheckpointMedia,
   mockCreateCheckpointMedia,
   mockDeleteCheckpointMedia,
+  mockReorderCheckpointMedia,
   mockToast,
 } = vi.hoisted(() => ({
   mockListCheckpointMedia: vi.fn(),
   mockCreateCheckpointMedia: vi.fn(),
   mockDeleteCheckpointMedia: vi.fn(),
+  mockReorderCheckpointMedia: vi.fn(),
   mockToast: { error: vi.fn(), success: vi.fn() },
 }));
 
-vi.mock('@/client', () => ({
+vi.mock("@/client", () => ({
   listCheckpointMedia: (...args: unknown[]) => mockListCheckpointMedia(...args),
   createCheckpointMedia: (...args: unknown[]) => mockCreateCheckpointMedia(...args),
   deleteCheckpointMedia: (...args: unknown[]) => mockDeleteCheckpointMedia(...args),
+  reorderCheckpointMedia: (...args: unknown[]) => mockReorderCheckpointMedia(...args),
 }));
 
-vi.mock('@/hooks/use-toast', () => ({
+vi.mock("@/hooks/use-toast", () => ({
   useAppToast: () => mockToast,
 }));
 
-vi.mock('@/components/themes/bloody', () => ({
-  BloodyButton: (props: React.ComponentProps<'button'>) => <button {...props} />,
+vi.mock("@/components/themes/bloody", () => ({
+  BloodyButton: (props: React.ComponentProps<"button">) => <button {...props} />,
 }));
 
 function renderWithClient(ui: React.ReactElement) {
@@ -38,170 +41,228 @@ function renderWithClient(ui: React.ReactElement) {
 
 const mediaItem = (overrides: Partial<any> = {}) => ({
   id: 1,
-  kind: 'photo',
+  checkpoint_id: 1,
+  kind: "photo",
   caption: null,
-  image_url: 'https://x/1.png',
+  order: 0,
+  title: null,
+  content_url: null,
+  content_text: null,
+  image_url: "https://x/1.png",
   ...overrides,
 });
 
-describe('CheckpointMediaManager', () => {
+describe("CheckpointMediaManager", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCreateCheckpointMedia.mockResolvedValue({ data: {} });
     mockDeleteCheckpointMedia.mockResolvedValue({ data: {} });
+    mockReorderCheckpointMedia.mockResolvedValue({ data: [] });
   });
 
-  it('shows loading state while fetching media', () => {
+  it("shows loading state while fetching media", () => {
     mockListCheckpointMedia.mockReturnValue(new Promise(() => {}));
     renderWithClient(<CheckpointMediaManager checkpointId={1} />);
-    expect(screen.getByText('A carregar…')).toBeInTheDocument();
+    expect(screen.getByText("A carregar…")).toBeInTheDocument();
   });
 
-  it('shows empty state when no photos exist', async () => {
+  it("shows the photo kind selected by default when empty", async () => {
     mockListCheckpointMedia.mockResolvedValue({ data: [] });
-    renderWithClient(<CheckpointMediaManager checkpointId={1} />);
-    expect(
-      await screen.findByText('Ainda sem fotos. Envie a primeira para a equipa adivinhar o sítio.'),
-    ).toBeInTheDocument();
+    const { container } = renderWithClient(<CheckpointMediaManager checkpointId={1} />);
+    await screen.findByText("(0)");
+    expect(container.querySelector('input[type="file"]')).toBeInTheDocument();
   });
 
-  it('renders photos and fun facts counts', async () => {
+  it("renders photo and fun fact rows with their counts", async () => {
     mockListCheckpointMedia.mockResolvedValue({
       data: [
-        mediaItem({ id: 1, caption: 'Nice spot' }),
-        mediaItem({ id: 2, kind: 'fun_fact', caption: 'Built in 1890', image_url: null }),
+        mediaItem({ id: 1, caption: "Nice spot" }),
+        mediaItem({ id: 2, kind: "fun_fact", caption: "Built in 1890", image_url: null }),
       ],
     });
     renderWithClient(<CheckpointMediaManager checkpointId={5} />);
-    expect(await screen.findByText('Nice spot')).toBeInTheDocument();
-    expect(screen.getByText('Built in 1890')).toBeInTheDocument();
-    expect(screen.getAllByText('(1)')).toHaveLength(2);
+    expect(await screen.findByText("Nice spot")).toBeInTheDocument();
+    expect(screen.getByText("Built in 1890")).toBeInTheDocument();
+    expect(screen.getByText("(2)")).toBeInTheDocument();
   });
 
-  it('uploads a photo when a file is selected', async () => {
+  it("uploads a photo when a file is selected", async () => {
     mockListCheckpointMedia.mockResolvedValue({ data: [] });
     const { container } = renderWithClient(<CheckpointMediaManager checkpointId={3} />);
-    await screen.findByText('Ainda sem fotos. Envie a primeira para a equipa adivinhar o sítio.');
+    await screen.findByText("(0)");
 
-    const file = new File(['data'], 'photo.png', { type: 'image/png' });
+    const file = new File(["data"], "photo.png", { type: "image/png" });
     const input = container.querySelector('input[type="file"]') as HTMLInputElement;
     fireEvent.change(input, { target: { files: [file] } });
+    fireEvent.click(screen.getByText("Adicionar"));
 
     await waitFor(() =>
       expect(mockCreateCheckpointMedia).toHaveBeenCalledWith({
         path: { checkpoint_id: 3 },
-        body: { kind: 'photo', caption: null, image: file },
+        body: {
+          kind: "photo",
+          caption: null,
+          title: null,
+          content_url: null,
+          content_text: null,
+          image: file,
+        },
       }),
     );
-    await waitFor(() => expect(mockToast.success).toHaveBeenCalledWith('Foto do sítio adicionada!'));
+    await waitFor(() => expect(mockToast.success).toHaveBeenCalledWith("Adicionado!"));
   });
 
-  it('shows error toast when photo upload fails', async () => {
+  it("shows error toast when adding media fails", async () => {
     mockListCheckpointMedia.mockResolvedValue({ data: [] });
-    mockCreateCheckpointMedia.mockRejectedValue(new Error('boom'));
-    const { container } = renderWithClient(<CheckpointMediaManager checkpointId={3} />);
-    await screen.findByText('Ainda sem fotos. Envie a primeira para a equipa adivinhar o sítio.');
+    mockCreateCheckpointMedia.mockRejectedValue(new Error("boom"));
+    renderWithClient(<CheckpointMediaManager checkpointId={3} />);
+    await screen.findByText("(0)");
 
-    const file = new File(['data'], 'photo.png', { type: 'image/png' });
-    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
-    fireEvent.change(input, { target: { files: [file] } });
+    fireEvent.click(screen.getByText("Adicionar"));
 
     await waitFor(() => expect(mockToast.error).toHaveBeenCalled());
   });
 
-  it('adds a fun fact via button click', async () => {
+  it("adds a fun fact after switching kind", async () => {
     mockListCheckpointMedia.mockResolvedValue({ data: [] });
     renderWithClient(<CheckpointMediaManager checkpointId={7} />);
-    await screen.findByText('Ainda sem fotos. Envie a primeira para a equipa adivinhar o sítio.');
+    await screen.findByText("(0)");
 
-    const input = screen.getByPlaceholderText('Ex: Este edifício foi construído em 1890…');
-    fireEvent.change(input, { target: { value: 'Fun fact here' } });
-    fireEvent.click(screen.getByText('Adicionar'));
+    fireEvent.click(screen.getByText("Curiosidade"));
+    const input = screen.getByPlaceholderText("Ex: Este edifício foi construído em 1890…");
+    fireEvent.change(input, { target: { value: "Fun fact here" } });
+    fireEvent.click(screen.getByText("Adicionar"));
 
     await waitFor(() =>
       expect(mockCreateCheckpointMedia).toHaveBeenCalledWith({
         path: { checkpoint_id: 7 },
-        body: { kind: 'fun_fact', caption: 'Fun fact here' },
+        body: {
+          kind: "fun_fact",
+          caption: "Fun fact here",
+          title: null,
+          content_url: null,
+          content_text: null,
+          image: null,
+        },
       }),
     );
   });
 
-  it('adds a fun fact via Enter key', async () => {
+  it("adds a QR attachment after switching kind", async () => {
     mockListCheckpointMedia.mockResolvedValue({ data: [] });
     renderWithClient(<CheckpointMediaManager checkpointId={7} />);
-    await screen.findByText('Ainda sem fotos. Envie a primeira para a equipa adivinhar o sítio.');
+    await screen.findByText("(0)");
 
-    const input = screen.getByPlaceholderText('Ex: Este edifício foi construído em 1890…');
-    fireEvent.change(input, { target: { value: 'Enter fact' } });
-    fireEvent.keyDown(input, { key: 'Enter' });
+    fireEvent.click(screen.getByText("QR code"));
+    const input = screen.getByPlaceholderText("URL ou texto a codificar no QR");
+    fireEvent.change(input, { target: { value: "https://example.com/riddle" } });
+    fireEvent.click(screen.getByText("Adicionar"));
 
     await waitFor(() =>
       expect(mockCreateCheckpointMedia).toHaveBeenCalledWith({
         path: { checkpoint_id: 7 },
-        body: { kind: 'fun_fact', caption: 'Enter fact' },
+        body: {
+          kind: "qr",
+          caption: null,
+          title: null,
+          content_url: null,
+          content_text: "https://example.com/riddle",
+          image: null,
+        },
       }),
     );
   });
 
-  it('does not add a fun fact when input is blank/whitespace', async () => {
+  it("adds a Spotify attachment with a title", async () => {
     mockListCheckpointMedia.mockResolvedValue({ data: [] });
     renderWithClient(<CheckpointMediaManager checkpointId={7} />);
-    await screen.findByText('Ainda sem fotos. Envie a primeira para a equipa adivinhar o sítio.');
+    await screen.findByText("(0)");
 
-    const input = screen.getByPlaceholderText('Ex: Este edifício foi construído em 1890…');
-    fireEvent.change(input, { target: { value: '   ' } });
-    expect(screen.getByText('Adicionar').closest('button')).toBeDisabled();
-    fireEvent.click(screen.getByText('Adicionar'));
-    expect(mockCreateCheckpointMedia).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByText("Spotify"));
+    fireEvent.change(screen.getByPlaceholderText("https://open.spotify.com/track/…"), {
+      target: { value: "https://open.spotify.com/track/abc123" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Título (opcional)"), {
+      target: { value: "Ouve isto" },
+    });
+    fireEvent.click(screen.getByText("Adicionar"));
+
+    await waitFor(() =>
+      expect(mockCreateCheckpointMedia).toHaveBeenCalledWith({
+        path: { checkpoint_id: 7 },
+        body: {
+          kind: "spotify",
+          caption: null,
+          title: "Ouve isto",
+          content_url: "https://open.spotify.com/track/abc123",
+          content_text: null,
+          image: null,
+        },
+      }),
+    );
   });
 
-  it('deletes a photo when the remove button is clicked', async () => {
+  it("deletes a media item when the remove button is clicked", async () => {
     mockListCheckpointMedia.mockResolvedValue({ data: [mediaItem({ id: 9 })] });
     renderWithClient(<CheckpointMediaManager checkpointId={2} />);
-    const removeBtn = await screen.findByLabelText('Remover foto');
+    const removeBtn = await screen.findByLabelText("Remover foto");
     fireEvent.click(removeBtn);
     await waitFor(() =>
       expect(mockDeleteCheckpointMedia).toHaveBeenCalledWith({ path: { media_id: 9 } }),
     );
   });
 
-  it('deletes a fun fact when the remove button is clicked', async () => {
-    mockListCheckpointMedia.mockResolvedValue({
-      data: [mediaItem({ id: 11, kind: 'fun_fact', caption: 'Old fact', image_url: null })],
-    });
-    renderWithClient(<CheckpointMediaManager checkpointId={2} />);
-    const removeBtn = await screen.findByLabelText('Remover curiosidade');
-    fireEvent.click(removeBtn);
-    await waitFor(() =>
-      expect(mockDeleteCheckpointMedia).toHaveBeenCalledWith({ path: { media_id: 11 } }),
-    );
-  });
-
-  it('shows error toast when delete fails', async () => {
+  it("shows error toast when delete fails", async () => {
     mockListCheckpointMedia.mockResolvedValue({ data: [mediaItem({ id: 9 })] });
-    mockDeleteCheckpointMedia.mockRejectedValue(new Error('fail'));
+    mockDeleteCheckpointMedia.mockRejectedValue(new Error("fail"));
     renderWithClient(<CheckpointMediaManager checkpointId={2} />);
-    const removeBtn = await screen.findByLabelText('Remover foto');
+    const removeBtn = await screen.findByLabelText("Remover foto");
     fireEvent.click(removeBtn);
     await waitFor(() => expect(mockToast.error).toHaveBeenCalled());
   });
 
-  it('includes photo caption when uploading', async () => {
+  it("reorders items with the up/down arrows", async () => {
+    mockListCheckpointMedia.mockResolvedValue({
+      data: [mediaItem({ id: 1 }), mediaItem({ id: 2, caption: "Second" })],
+    });
+    renderWithClient(<CheckpointMediaManager checkpointId={2} />);
+    await screen.findByText("(2)");
+
+    const downButtons = screen.getAllByLabelText("Mover para baixo");
+    fireEvent.click(downButtons[0]!);
+
+    await waitFor(() =>
+      expect(mockReorderCheckpointMedia).toHaveBeenCalledWith({
+        path: { checkpoint_id: 2 },
+        body: [2, 1],
+      }),
+    );
+  });
+
+  it("includes photo caption when uploading", async () => {
     mockListCheckpointMedia.mockResolvedValue({ data: [] });
     const { container } = renderWithClient(<CheckpointMediaManager checkpointId={4} />);
-    await screen.findByText('Ainda sem fotos. Envie a primeira para a equipa adivinhar o sítio.');
+    await screen.findByText("(0)");
 
-    fireEvent.change(screen.getByPlaceholderText('Legenda (opcional)'), {
-      target: { value: 'Sunset view' },
+    fireEvent.change(screen.getByPlaceholderText("Legenda (opcional)"), {
+      target: { value: "Sunset view" },
     });
-    const file = new File(['data'], 'photo.png', { type: 'image/png' });
+    const file = new File(["data"], "photo.png", { type: "image/png" });
     const input = container.querySelector('input[type="file"]') as HTMLInputElement;
     fireEvent.change(input, { target: { files: [file] } });
+    fireEvent.click(screen.getByText("Adicionar"));
 
     await waitFor(() =>
       expect(mockCreateCheckpointMedia).toHaveBeenCalledWith({
         path: { checkpoint_id: 4 },
-        body: { kind: 'photo', caption: 'Sunset view', image: file },
+        body: {
+          kind: "photo",
+          caption: "Sunset view",
+          title: null,
+          content_url: null,
+          content_text: null,
+          image: file,
+        },
       }),
     );
   });

--- a/web-rally/tests/unit/utils/errorHandling.test.ts
+++ b/web-rally/tests/unit/utils/errorHandling.test.ts
@@ -19,6 +19,23 @@ describe('getErrorMessage', () => {
     expect(getErrorMessage(42, 'fallback')).toBe('fallback')
   })
 
+  it('extracts top-level detail (generated client throwOnError shape) when present', () => {
+    const error = { detail: 'Image upload is disabled: R2 storage is not configured.' }
+    expect(getErrorMessage(error, 'fallback')).toBe(
+      'Image upload is disabled: R2 storage is not configured.',
+    )
+  })
+
+  it('prefers top-level detail over body.detail', () => {
+    const error = { detail: 'from top level', body: { detail: 'from body' } }
+    expect(getErrorMessage(error, 'fallback')).toBe('from top level')
+  })
+
+  it('ignores non-string top-level detail', () => {
+    const error = { detail: 123, message: 'Network failure' }
+    expect(getErrorMessage(error, 'fallback')).toBe('Network failure')
+  })
+
   it('extracts body.detail when present', () => {
     const error = { body: { detail: 'Team not found' } }
     expect(getErrorMessage(error, 'fallback')).toBe('Team not found')


### PR DESCRIPTION
Checkpoint media only ever meant "photo" or "fun fact". The real event planning documents this app is modeled on also want a QR code (scan for a riddle/challenge), a Spotify link, or a plain external link, attached to a post alongside photos.

## Backend
- `MediaKind` gains `qr`/`spotify`/`link`; `CheckpointMedia` gains `content_url` (spotify/link, never touches R2), `content_text` (qr payload), `title` (spotify/link label)
- Per-kind validation (spotify must be `open.spotify.com`, link must be http(s), qr non-empty/≤2000 chars, every kind rejects fields it doesn't use instead of silently dropping them)
- Migration 0041 — first migration in this repo adding values to an existing Postgres enum
- 31 Postgres-backed tests + 23 pure schema-validator unit tests. mypy/ruff clean
- `clue_media_url` (legacy single-image field) untouched — zero regression risk to the existing flow

## Frontend
- Admin: `CheckpointMediaManager` slimmed to an orchestrator, kind selector dispatches to per-kind field components (same split pattern as `PenaltyCounterConfigFields`/`QuizQuestionConfigFields`). QR live preview. Reorder via up/down arrows against the existing (previously unused) reorder endpoint
- Team-facing: `CheckpointMediaAttachment` dispatches qr/spotify/link rendering inside `CheckpointDiscovery`, photo/fun_fact unchanged
- 205/205 test files, 1600/1600 tests passing across the whole frontend suite. tsc/eslint clean